### PR TITLE
F support 18 dof and v1

### DIFF
--- a/cyberglove/README.md
+++ b/cyberglove/README.md
@@ -1,6 +1,6 @@
-**cyberglove** is a generic ROS interface to Immersion's Cyberglove dataglove. It reads the data from the Cyberglove, calibrate them using a calibration file and stream them to 2 different `/joint_states` topics: one for the raw data the other one for the calibrated data. There's a utility in `sr_control_gui` which can be used to generate a calibration file for a specific user in a few steps.
+**cyberglove** is a generic ROS interface to Immersion's Cyberglove dataglove. It reads the data from the Cyberglove, calibrate them using a calibration file and stream them to 2 different `/joint_states` topics: one for the raw data the other one for the calibrated data. There's a utility in `sr_visualization` which can be used to generate a calibration file for a specific user in a few steps.
 
-If the button on the wrist is off, the glove won't publish any data.
+If the button on the wrist is off, the glove won't publish any data (version 2 and above).
 
 The calibration file can't be dynamically loaded for the time being, so if you change the calibration then don't forget to restart the cyberglove node.
 
@@ -15,10 +15,12 @@ $ roslaunch cyberglove cyberglove.launch
 
 You can specify some parameters in the launch file:
 
-* cyberglove_prefix The prefix to put in front of the joint_states published by the glove.
-* publish_frequency The frequency at which you want to publish the data.
-* path_to_glove The path to the port on which the Cyberglove is connected (usually `/dev/ttyS0`)
-* path_to_calibration The path to the calibration file for the Cyberglove
+* serial_port: The path to the port on which the Cyberglove is connected (default `/dev/ttyS0`)
+* calibration: The path to the calibration file for the Cyberglove (default:"$(find sr_cyberglove_config)/calibrations/cyberglove.cal)
+* version: The version of the Cyberglove the driver connects to (default 2)
+* joint_numner: The number of joints/sensors the Cyberglove has (18 or default:22)
+* protocol: The protocol to use (default:8bit or 16bit)
+* filter: If the hardware filter should be activated (default: true)
 
 Code API
 --------

--- a/cyberglove/include/cyberglove/cyberglove_publisher.h
+++ b/cyberglove/include/cyberglove/cyberglove_publisher.h
@@ -43,66 +43,67 @@
 
 using namespace ros;
 
-namespace cyberglove{
+namespace cyberglove
+{
 
-  class CyberglovePublisher
-  {
-  public:
-    /// Constructor
-    CyberglovePublisher();
+class CyberglovePublisher
+{
+public:
+  /// Constructor
+  CyberglovePublisher();
 
-    /// Destructor
-    ~CyberglovePublisher();
+  /// Destructor
+  ~CyberglovePublisher();
 
-    Publisher cyberglove_pub;
-    void initialize_calibration(std::string path_to_calibration);
-    bool isPublishing();
-    void setPublishing(bool value);
-  private:
-    /////////////////
-    //  CALLBACKS  //
-    /////////////////
+  Publisher cyberglove_pub;
+  void initialize_calibration(std::string path_to_calibration);
+  bool isPublishing();
+  void setPublishing(bool value);
+private:
+  /////////////////
+  //  CALLBACKS  //
+  /////////////////
 
-    //ros node handle
-    NodeHandle node, n_tilde;
-    unsigned int publish_counter_max, publish_counter_index;
+  //ros node handle
+  NodeHandle node, n_tilde;
+  unsigned int publish_counter_max, publish_counter_index;
 
-    ///the actual connection with the cyberglove is done here.
-    boost::shared_ptr<CybergloveSerial> serial_glove;
+  ///the actual connection with the cyberglove is done here.
+  boost::shared_ptr<CybergloveSerial> serial_glove;
 
-    /**
-     * The callback function: called each time a full message
-     * is received. This function is bound to the serial_glove
-     * object using boost::bind.
-     *
-     * @param glove_pos A vector containing the current raw joints positions.
-     * @param light_on true if the light is on, false otherwise.
-     */
-    void glove_callback(std::vector<float> glove_pos, bool light_on);
+  /**
+   * The callback function: called each time a full message
+   * is received. This function is bound to the serial_glove
+   * object using boost::bind.
+   *
+   * @param glove_pos A vector containing the current raw joints positions.
+   * @param light_on true if the light is on, false otherwise.
+   */
+  void glove_callback(std::vector<float> glove_pos, bool light_on);
 
-    std::string path_to_glove;
-    bool publishing;
+  std::string path_to_glove;
+  bool publishing;
 
-    ///the calibration parser
-    xml_calibration_parser::XmlCalibrationParser calibration_parser;
+  ///the calibration parser
+  xml_calibration_parser::XmlCalibrationParser calibration_parser;
 
-    Publisher cyberglove_raw_pub;
+  Publisher cyberglove_raw_pub;
 
-    sensor_msgs::JointState jointstate_msg;
-    sensor_msgs::JointState jointstate_raw_msg;
+  sensor_msgs::JointState jointstate_msg;
+  sensor_msgs::JointState jointstate_raw_msg;
 
-    void add_jointstate(float position, std::string joint_name);
+  void add_jointstate(float position, std::string joint_name);
 
-    std::vector<float> calibration_values;
+  std::vector<float> calibration_values;
 
-    std::vector<std::vector<float> > glove_positions;
+  std::vector<std::vector<float> > glove_positions;
 
-    std::string cyberglove_version_;
-    int cyberglove_joint_number_;
-    std::string streaming_protocol_;
-  }; // end class CyberglovePublisher
+  std::string cyberglove_version_;
+  int cyberglove_joint_number_;
+  std::string streaming_protocol_;
+}; // end class CyberglovePublisher
 
-} // end namespace
+}  // namespace cyberglove
 #endif 	    /* !CYBERGLOVE_PUBLISHER_H_ */
 
 /* For the emacs weenies in the crowd.

--- a/cyberglove/include/cyberglove/cyberglove_publisher.h
+++ b/cyberglove/include/cyberglove/cyberglove_publisher.h
@@ -98,6 +98,7 @@ namespace cyberglove{
     std::vector<std::vector<float> > glove_positions;
 
     std::string cyberglove_version_;
+    int cyberglove_joint_number_;
     std::string streaming_protocol_;
   }; // end class CyberglovePublisher
 

--- a/cyberglove/include/cyberglove/cyberglove_publisher.h
+++ b/cyberglove/include/cyberglove/cyberglove_publisher.h
@@ -28,24 +28,22 @@
  *
  */
 
-#ifndef   	CYBERGLOVE_PUBLISHER_H_
-# define   	CYBERGLOVE_PUBLISHER_H_
+#ifndef CYBERGLOVE_PUBLISHER_H
+#define CYBERGLOVE_PUBLISHER_H
 
 #include <ros/ros.h>
-#include <vector>
 #include <boost/smart_ptr.hpp>
+#include <string>
+#include <vector>
 
 #include "cyberglove/serial_glove.hpp"
 
-//messages
+// messages
 #include <sensor_msgs/JointState.h>
 #include "cyberglove/xml_calibration_parser.h"
 
-using namespace ros;
-
 namespace cyberglove
 {
-
 class CyberglovePublisher
 {
 public:
@@ -55,20 +53,21 @@ public:
   /// Destructor
   ~CyberglovePublisher();
 
-  Publisher cyberglove_pub;
+  ros::Publisher cyberglove_pub;
   void initialize_calibration(std::string path_to_calibration);
   bool isPublishing();
   void setPublishing(bool value);
+
 private:
   /////////////////
   //  CALLBACKS  //
   /////////////////
 
-  //ros node handle
-  NodeHandle node, n_tilde;
+  // ros node handle
+  ros::NodeHandle node, n_tilde;
   unsigned int publish_counter_max, publish_counter_index;
 
-  ///the actual connection with the cyberglove is done here.
+  /// the actual connection with the cyberglove is done here.
   boost::shared_ptr<CybergloveSerial> serial_glove;
 
   /**
@@ -84,10 +83,10 @@ private:
   std::string path_to_glove;
   bool publishing;
 
-  ///the calibration parser
+  /// the calibration parser
   xml_calibration_parser::XmlCalibrationParser calibration_parser;
 
-  Publisher cyberglove_raw_pub;
+  ros::Publisher cyberglove_raw_pub;
 
   sensor_msgs::JointState jointstate_msg;
   sensor_msgs::JointState jointstate_raw_msg;
@@ -101,10 +100,10 @@ private:
   std::string cyberglove_version_;
   int cyberglove_joint_number_;
   std::string streaming_protocol_;
-}; // end class CyberglovePublisher
+};  // end class CyberglovePublisher
 
 }  // namespace cyberglove
-#endif 	    /* !CYBERGLOVE_PUBLISHER_H_ */
+#endif  // CYBERGLOVE_PUBLISHER_H
 
 /* For the emacs weenies in the crowd.
 Local Variables:

--- a/cyberglove/include/cyberglove/cyberglove_service.h
+++ b/cyberglove/include/cyberglove/cyberglove_service.h
@@ -39,25 +39,25 @@
 
 using namespace ros;
 
-namespace cyberglove{
+namespace cyberglove
+{
 
-  class CybergloveService
-  {
-  public:
-    /// Constructor
-    CybergloveService(boost::shared_ptr<CyberglovePublisher> publish);
-    ~CybergloveService(){};
+class CybergloveService
+{
+public:
+  /// Constructor
+  CybergloveService(boost::shared_ptr<CyberglovePublisher> publish);
+  ~CybergloveService(){};
 
-    //CybergloveService();
-    bool start(cyberglove::Start::Request &req, cyberglove::Start::Response &res);
-    bool calibration(cyberglove::Calibration::Request &req, cyberglove::Calibration::Response &res);
-  private:
+  //CybergloveService();
+  bool start(cyberglove::Start::Request &req, cyberglove::Start::Response &res);
+  bool calibration(cyberglove::Calibration::Request &req, cyberglove::Calibration::Response &res);
+private:
 
-    NodeHandle node;
-    boost::shared_ptr<CyberglovePublisher> pub;
-    ros::ServiceServer service_start;
-    ros::ServiceServer service_calibration;
-  };
-
-}
+  NodeHandle node;
+  boost::shared_ptr<CyberglovePublisher> pub;
+  ros::ServiceServer service_start;
+  ros::ServiceServer service_calibration;
+};
+}  // namespace cyberglove
 #endif

--- a/cyberglove/include/cyberglove/cyberglove_service.h
+++ b/cyberglove/include/cyberglove/cyberglove_service.h
@@ -24,40 +24,37 @@
  *
  */
 
-
-#ifndef   	CYBERGLOVE_SERVICE_H_
-# define   	CYBERGLOVE_SERVICE_H_
+#ifndef CYBERGLOVE_SERVICE_H
+#define CYBERGLOVE_SERVICE_H
 
 #include <ros/ros.h>
-#include <vector>
-#include "cyberglove_publisher.h"
-#include "cyberglove/Start.h"
-#include "cyberglove/Calibration.h"
 #include <boost/smart_ptr.hpp>
+#include <vector>
+#include "cyberglove/Calibration.h"
+#include "cyberglove/Start.h"
+#include "cyberglove/cyberglove_publisher.h"
 
-//messages
-
-using namespace ros;
+// messages
 
 namespace cyberglove
 {
-
 class CybergloveService
 {
 public:
   /// Constructor
-  CybergloveService(boost::shared_ptr<CyberglovePublisher> publish);
-  ~CybergloveService(){};
+  explicit CybergloveService(boost::shared_ptr<CyberglovePublisher> publish);
+  ~CybergloveService()
+  {};
 
-  //CybergloveService();
+  // CybergloveService();
   bool start(cyberglove::Start::Request &req, cyberglove::Start::Response &res);
   bool calibration(cyberglove::Calibration::Request &req, cyberglove::Calibration::Response &res);
-private:
 
-  NodeHandle node;
+private:
+  ros::NodeHandle node;
   boost::shared_ptr<CyberglovePublisher> pub;
   ros::ServiceServer service_start;
   ros::ServiceServer service_calibration;
 };
 }  // namespace cyberglove
-#endif
+#endif  // CYBERGLOVE_SERVICE_H

--- a/cyberglove/include/cyberglove/serial_glove.hpp
+++ b/cyberglove/include/cyberglove/serial_glove.hpp
@@ -67,8 +67,9 @@
 
 #include <cereal_port/CerealPort.h>
 #include <boost/smart_ptr.hpp>
-
 #include <boost/function.hpp>
+#include <string>
+#include <vector>
 
 namespace cyberglove_freq
 {
@@ -92,7 +93,6 @@ struct CybergloveFreq
 
 namespace cyberglove
 {
-
 enum reception_state
 {
   INITIAL,
@@ -124,7 +124,8 @@ public:
    * @param callback a pointer to a callback function, which will be called each time a
    *                 complete joint message is received.
    */
-  CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback);
+  CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size,
+                   std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback);
   ~CybergloveSerial();
 
   /**
@@ -218,7 +219,7 @@ private:
 
   bool light_on, button_on;
 
-  ///Did we get any garbage in the received message?
+  /// Did we get any garbage in the received message?
   bool no_errors;
 
   std::string cyberglove_version_;

--- a/cyberglove/include/cyberglove/serial_glove.hpp
+++ b/cyberglove/include/cyberglove/serial_glove.hpp
@@ -124,7 +124,7 @@ namespace cyberglove
      * @param callback a pointer to a callback function, which will be called each time a
      *                 complete joint message is received.
      */
-    CybergloveSerial(std::string serial_port, std::string cyberglove_version, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback);
+    CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback);
     ~CybergloveSerial();
 
     /**
@@ -203,6 +203,7 @@ namespace cyberglove
     void stream_callback(char* world, int length);
 
     int nb_msgs_received, glove_pos_index, timestamp_bytes_, byte_index_;
+    const unsigned short glove_size_;
     /// A vector containing the current joints positions.
     std::vector<float> glove_positions;
 

--- a/cyberglove/include/cyberglove/serial_glove.hpp
+++ b/cyberglove/include/cyberglove/serial_glove.hpp
@@ -72,161 +72,161 @@
 
 namespace cyberglove_freq
 {
+/**
+ * This structure contains the different strings which are written
+ * to the serial port in order to get a given streaming frequency.
+ */
+struct CybergloveFreq
+{
   /**
-   * This structure contains the different strings which are written
-   * to the serial port in order to get a given streaming frequency.
+   *The fastest frequency is only used when testing the maximum transmission
+   * speed: it's not a stable frequency for the glove.
    */
-  struct CybergloveFreq
-  {
-    /**
-     *The fastest frequency is only used when testing the maximum transmission
-     * speed: it's not a stable frequency for the glove.
-     */
-    static const std::string fastest;
-    static const std::string hundred_hz;
-    static const std::string fourtyfive_hz;
-    static const std::string ten_hz;
-    static const std::string one_hz;
-  };
-}
+  static const std::string fastest;
+  static const std::string hundred_hz;
+  static const std::string fourtyfive_hz;
+  static const std::string ten_hz;
+  static const std::string one_hz;
+};
+}  // namespace cyberglove_freq
 
 namespace cyberglove
 {
 
-  enum reception_state
-  {
-    INITIAL,
-    RECEIVING_FRAME
-  };
+enum reception_state
+{
+  INITIAL,
+  RECEIVING_FRAME
+};
 
-  namespace reception_16bit
-  {
-    enum reception_state_16bit
-    {
-      SYNCHRONIZATION_1,
-      SYNCHRONIZATION_2,
-      SYNCHRONIZATION_3,
-      TIMESTAMP,
-      RECEIVING_FRAME
-    };
-  }
+namespace reception_16bit
+{
+enum reception_state_16bit
+{
+  SYNCHRONIZATION_1,
+  SYNCHRONIZATION_2,
+  SYNCHRONIZATION_3,
+  TIMESTAMP,
+  RECEIVING_FRAME
+};
+}  // namespace reception_16bit
+   /**
+    * This class uses the Cereal Port ROS package to connect to
+    * and interact with the Cyberglove.
+    */
+class CybergloveSerial
+{
+public:
   /**
-   * This class uses the Cereal Port ROS package to connect to
-   * and interact with the Cyberglove.
+   * Initializes the connection with the cyberglove through the given serial port.
+   *
+   * @param serial_port the path to the serial port, /dev/ttyS0 by default
+   * @param callback a pointer to a callback function, which will be called each time a
+   *                 complete joint message is received.
    */
-  class CybergloveSerial
-  {
-  public:
-    /**
-     * Initializes the connection with the cyberglove through the given serial port.
-     *
-     * @param serial_port the path to the serial port, /dev/ttyS0 by default
-     * @param callback a pointer to a callback function, which will be called each time a
-     *                 complete joint message is received.
-     */
-    CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback);
-    ~CybergloveSerial();
+  CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback);
+  ~CybergloveSerial();
 
-    /**
-     * Turns on or off the filtering (done directly in the cyberglove). By default the filtering
-     * is activated. We recommend turning it off if you want to do oversampling, to get the fastest
-     * rate (the rate is divided by 2-3 if the filtering is on)
-     *
-     * @param value true if you want to turn it on.
-     *
-     * @return 0 if success
-     */
-    int set_filtering(bool value);
+  /**
+   * Turns on or off the filtering (done directly in the cyberglove). By default the filtering
+   * is activated. We recommend turning it off if you want to do oversampling, to get the fastest
+   * rate (the rate is divided by 2-3 if the filtering is on)
+   *
+   * @param value true if you want to turn it on.
+   *
+   * @return 0 if success
+   */
+  int set_filtering(bool value);
 
-    /**
-     * Turns on or off the status transmission: if it's on, then a char is added to the message
-     * to describe the current status of the glove. For this status byte, the bit 1 corresponds
-     * to the button status, and the bit 2 corresponds to the light status.
-     *
-     * @param value true if you want to turn it on.
-     *
-     * @return 0 if success
-     */
-    int set_transmit_info(bool value);
+  /**
+   * Turns on or off the status transmission: if it's on, then a char is added to the message
+   * to describe the current status of the glove. For this status byte, the bit 1 corresponds
+   * to the button status, and the bit 2 corresponds to the light status.
+   *
+   * @param value true if you want to turn it on.
+   *
+   * @return 0 if success
+   */
+  int set_transmit_info(bool value);
 
-    /**
-     * Set the transmit frequency for the cyberglove.
-     *
-     * @param frequency use the elements of the struct cyberglove_freq::CybergloveFreq
-     *
-     * @return 0 if success
-     */
-    int set_frequency(std::string frequency);
+  /**
+   * Set the transmit frequency for the cyberglove.
+   *
+   * @param frequency use the elements of the struct cyberglove_freq::CybergloveFreq
+   *
+   * @return 0 if success
+   */
+  int set_frequency(std::string frequency);
 
-    /**
-     * Start streaming the data from the cyberglove, calling the
-     * callback function each time the full message is received.
-     *
-     * @return 0 if success
-     */
-    int start_stream();
+  /**
+   * Start streaming the data from the cyberglove, calling the
+   * callback function each time the full message is received.
+   *
+   * @return 0 if success
+   */
+  int start_stream();
 
-    /**
-     * We keep the count of all the messages received for the glove.
-     *
-     * @return the number of received messages.
-     */
-    int get_nb_msgs_received();
+  /**
+   * We keep the count of all the messages received for the glove.
+   *
+   * @return the number of received messages.
+   */
+  int get_nb_msgs_received();
 
-    /**
-     * The number of sensors in the glove.
-     */
-    static const unsigned short glove_size;
+  /**
+   * The number of sensors in the glove.
+   */
+  static const unsigned short glove_size;
 
-    /**
-     * The length of the timestamp in the 16bit protocol.
-     */
-    static const unsigned short timestamp_size;
+  /**
+   * The length of the timestamp in the 16bit protocol.
+   */
+  static const unsigned short timestamp_size;
 
-  private:
-    /**
-     * CerealPort is the ROS library used to talk
-     * to the serial port.
-     */
-    boost::shared_ptr<cereal::CerealPort> cereal_port;
+private:
+  /**
+   * CerealPort is the ROS library used to talk
+   * to the serial port.
+   */
+  boost::shared_ptr<cereal::CerealPort> cereal_port;
 
-    /**
-     * The callback function for the raw data coming from the
-     * serial port, bound to the cereal_port callback. The data received
-     * here is not received message by messages: it's a stream of data, coming
-     * at different intervals (the whole messages are received at a given frequency
-     * though)
-     *
-     * @param world a table of char containing the binary values from the serial port
-     * @param length the length of the received message.
-     */
-    void stream_callback(char* world, int length);
+  /**
+   * The callback function for the raw data coming from the
+   * serial port, bound to the cereal_port callback. The data received
+   * here is not received message by messages: it's a stream of data, coming
+   * at different intervals (the whole messages are received at a given frequency
+   * though)
+   *
+   * @param world a table of char containing the binary values from the serial port
+   * @param length the length of the received message.
+   */
+  void stream_callback(char* world, int length);
 
-    int nb_msgs_received, glove_pos_index, timestamp_bytes_, byte_index_;
-    const unsigned short glove_size_;
-    /// A vector containing the current joints positions.
-    std::vector<float> glove_positions;
+  int nb_msgs_received, glove_pos_index, timestamp_bytes_, byte_index_;
+  const unsigned short glove_size_;
+  /// A vector containing the current joints positions.
+  std::vector<float> glove_positions;
 
-    unsigned int current_value;
-    unsigned int sensor_value_;
+  unsigned int current_value;
+  unsigned int sensor_value_;
 
-    /**
-     * The pointer to the function called each time a full message is received.
-     * This function is linked when instantiating the class.
-     */
-    boost::function<void(std::vector<float>, bool)> callback_function;
+  /**
+   * The pointer to the function called each time a full message is received.
+   * This function is linked when instantiating the class.
+   */
+  boost::function<void(std::vector<float>, bool)> callback_function;
 
-    bool light_on, button_on;
+  bool light_on, button_on;
 
-    ///Did we get any garbage in the received message?
-    bool no_errors;
+  ///Did we get any garbage in the received message?
+  bool no_errors;
 
-    std::string cyberglove_version_;
-    std::string streaming_protocol_;
+  std::string cyberglove_version_;
+  std::string streaming_protocol_;
 
-    unsigned int reception_state_;
-  };
-}
+  unsigned int reception_state_;
+};
+}  // namespace cyberglove
 
 /* For the emacs weenies in the crowd.
 Local Variables:

--- a/cyberglove/include/cyberglove/xml_calibration_parser.h
+++ b/cyberglove/include/cyberglove/xml_calibration_parser.h
@@ -35,27 +35,27 @@
  *
  */
 
+#ifndef XML_CALIBRATION_PARSER_H
+#define XML_CALIBRATION_PARSER_H
 
-#ifndef   	XML_CALIBRATION_PARSER_H_
-# define   	XML_CALIBRATION_PARSER_H_
-
-//xml parser library
+// xml parser library
 #include <tinyxml.h>
 
-//generic C/C++ include
+// generic C/C++ include
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 namespace xml_calibration_parser
 {
-
 class XmlCalibrationParser
 {
- public:
-  XmlCalibrationParser(){};
-  XmlCalibrationParser(std::string path_to_calibration);
-  ~XmlCalibrationParser(){};
+public:
+  XmlCalibrationParser()
+  {};
+  explicit XmlCalibrationParser(std::string path_to_calibration);
+  ~XmlCalibrationParser()
+  {};
 
   float get_calibration_value(float position, std::string joint_name);
 
@@ -71,12 +71,11 @@ class XmlCalibrationParser
     std::vector<Calibration> calibrations;
   };
 
-
   std::vector<JointCalibration> getJointsCalibrations();
 
- protected:
-  void parse_calibration_file( TiXmlNode* pParent );
-  std::vector<Calibration> parse_joint_attributes( TiXmlNode* pParent );
+protected:
+  void parse_calibration_file(TiXmlNode* pParent);
+  std::vector<Calibration> parse_joint_attributes(TiXmlNode* pParent);
 
   /// The vector containing the calibration
   std::vector<JointCalibration> jointsCalibrations;
@@ -90,9 +89,7 @@ class XmlCalibrationParser
 
   float compute_lookup_value(int index, std::vector<Calibration> calib);
 
-  float linear_interpolate( float x ,
-			    float x0, float y0,
-			    float x1, float y1 );
+  float linear_interpolate(float x, float x0, float y0, float x1, float y1);
 
   // consts for the lookup tables
   static const float lookup_precision;
@@ -127,10 +124,9 @@ class XmlCalibrationParser
    */
   static inline float return_raw_position_from_index(int lookup_index)
   {
-    return ((float)lookup_index)/lookup_precision;
+    return static_cast<float>(lookup_index) / lookup_precision;
   };
-
-}; // end class XmlCalibrationParser
+};  // end class XmlCalibrationParser
 
 }  // namespace xml_calibration_parser
-#endif 	    /* !XML_CALIBRATION_PARSER_H_ */
+#endif  // XML_CALIBRATION_PARSER_H

--- a/cyberglove/include/cyberglove/xml_calibration_parser.h
+++ b/cyberglove/include/cyberglove/xml_calibration_parser.h
@@ -47,7 +47,8 @@
 #include <vector>
 #include <map>
 
-namespace xml_calibration_parser{
+namespace xml_calibration_parser
+{
 
 class XmlCalibrationParser
 {
@@ -131,5 +132,5 @@ class XmlCalibrationParser
 
 }; // end class XmlCalibrationParser
 
-} // end namespace
+}  // namespace xml_calibration_parser
 #endif 	    /* !XML_CALIBRATION_PARSER_H_ */

--- a/cyberglove/launch/cyberglove.launch
+++ b/cyberglove/launch/cyberglove.launch
@@ -2,6 +2,7 @@
   <arg name="serial_port" default="/dev/ttyUSB0"/>
   <arg name="calibration" default="$(find sr_cyberglove_config)/calibrations/cyberglove.cal"/>
   <arg name="version" default="2"/>
+  <arg name="joint_number" default="22"/>
   <arg name="protocol" default="8bit"/>
   <!-- Activate internal cybeglove data filtering -->
   <arg name="filter" default="true"/>
@@ -24,6 +25,7 @@
     <param name="path_to_glove" type="string" value="$(arg serial_port)" />
     <param name="path_to_calibration" type="string" value="$(arg calibration)" />
     <param name="cyberglove_version" type="string" value="$(arg version)" />
+    <param name="cyberglove_joint_number" type="int" value="$(arg joint_number)" />
     <param name="streaming_protocol" type="string" value="$(arg protocol)" />
     <param name="filter" type="bool" value="$(arg filter)" />
   </node>

--- a/cyberglove/launch/cyberglove.launch
+++ b/cyberglove/launch/cyberglove.launch
@@ -9,7 +9,7 @@
   <param name="robot_description" textfile="$(find
   cyberglove)/model/cyberglove.xml"/>
 
-  <node pkg="cyberglove" name="cyberglove" type="cyberglove_node" >
+  <node pkg="cyberglove" name="cyberglove" type="cyberglove_node" output="screen" >
     <param name="cyberglove_prefix" type="string" value="/cyberglove" />
     <!-- We're doing some oversampling. You can set the frequency at which
 	 the data are sampled as well as the frequency at which they're published

--- a/cyberglove/src/cyberglove_node.cpp
+++ b/cyberglove/src/cyberglove_node.cpp
@@ -27,17 +27,16 @@
 
 #include <ros/ros.h>
 #include <time.h>
+#include <boost/smart_ptr.hpp>
+#include "cyberglove/Start.h"
 #include "cyberglove/cyberglove_publisher.h"
 #include "cyberglove/cyberglove_service.h"
-#include "cyberglove/Start.h"
-#include <boost/smart_ptr.hpp>
 
 using namespace cyberglove;
 
 /////////////////////////////////
 //           MAIN              //
 /////////////////////////////////
-
 
 /**
  *  Start the cyberglove publisher.
@@ -50,7 +49,7 @@ using namespace cyberglove;
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "cyberglove_publisher");
-  //NodeHandle n;
+  // NodeHandle n;
   try
   {
     boost::shared_ptr<CyberglovePublisher> cyberglove_pub(new CyberglovePublisher());
@@ -62,10 +61,9 @@ int main(int argc, char** argv)
     ROS_FATAL("could not create publisher, leaving");
     return -1;
   }
-  
+
   return 0;
 }
-
 
 /* For the emacs weenies in the crowd.
 Local Variables:

--- a/cyberglove/src/cyberglove_node.cpp
+++ b/cyberglove/src/cyberglove_node.cpp
@@ -51,12 +51,18 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "cyberglove_publisher");
   //NodeHandle n;
-  boost::shared_ptr<CyberglovePublisher> cyberglove_pub(new CyberglovePublisher());
-
-  CybergloveService service(cyberglove_pub);
-
-  ros::spin();
-
+  try
+  {
+    boost::shared_ptr<CyberglovePublisher> cyberglove_pub(new CyberglovePublisher());
+    CybergloveService service(cyberglove_pub);
+    ros::spin();
+  }
+  catch (int e)
+  {
+    ROS_FATAL("could not create publisher, leaving");
+    return -1;
+  }
+  
   return 0;
 }
 

--- a/cyberglove/src/cyberglove_publisher.cpp
+++ b/cyberglove/src/cyberglove_publisher.cpp
@@ -40,233 +40,233 @@ using namespace xml_calibration_parser;
 
 namespace cyberglove{
 
-  /////////////////////////////////
-  //    CONSTRUCTOR/DESTRUCTOR   //
-  /////////////////////////////////
+/////////////////////////////////
+//    CONSTRUCTOR/DESTRUCTOR   //
+/////////////////////////////////
 
-  CyberglovePublisher::CyberglovePublisher()
-    : n_tilde("~"), publish_counter_max(0), publish_counter_index(0),
-      path_to_glove("/dev/ttyS0"), publishing(true)
+CyberglovePublisher::CyberglovePublisher()
+  : n_tilde("~"), publish_counter_max(0), publish_counter_index(0),
+    path_to_glove("/dev/ttyS0"), publishing(true)
+{
+
+  std::string path_to_calibration;
+  n_tilde.param("path_to_calibration", path_to_calibration, std::string("/etc/robot/calibration.d/cyberglove.cal"));
+  ROS_INFO("Calibration file loaded for the Cyberglove: %s", path_to_calibration.c_str());
+
+  initialize_calibration(path_to_calibration);
+
+  //set sampling frequency
+  double sampling_freq;
+  n_tilde.param("sampling_frequency", sampling_freq, 100.0);
+
+  // set publish_counter: the number of data we'll average
+  // before publishing.
+  double publish_freq;
+  n_tilde.param("publish_frequency", publish_freq, 20.0);
+  publish_counter_max = (int)(sampling_freq / publish_freq);
+
+  ROS_INFO_STREAM("Sampling at " << sampling_freq << "Hz ; Publishing at "
+                  << publish_freq << "Hz ; Publish counter: "<< publish_counter_max);
+
+  //Get the cyberglove version '1', '2' or '3'
+  n_tilde.param("cyberglove_version", cyberglove_version_, std::string("2"));
+  ROS_INFO("Cyberglove version: %s", cyberglove_version_.c_str());
+  
+  //Get the cyberglove joint number '18' or '22'
+  n_tilde.param("cyberglove_joint_number", cyberglove_joint_number_, 22);
+  if (cyberglove_joint_number_ != 22 && cyberglove_joint_number_ != 18)
   {
-
-    std::string path_to_calibration;
-    n_tilde.param("path_to_calibration", path_to_calibration, std::string("/etc/robot/calibration.d/cyberglove.cal"));
-    ROS_INFO("Calibration file loaded for the Cyberglove: %s", path_to_calibration.c_str());
-
-    initialize_calibration(path_to_calibration);
-
-    //set sampling frequency
-    double sampling_freq;
-    n_tilde.param("sampling_frequency", sampling_freq, 100.0);
-
-    // set publish_counter: the number of data we'll average
-    // before publishing.
-    double publish_freq;
-    n_tilde.param("publish_frequency", publish_freq, 20.0);
-    publish_counter_max = (int)(sampling_freq / publish_freq);
-
-    ROS_INFO_STREAM("Sampling at " << sampling_freq << "Hz ; Publishing at "
-                    << publish_freq << "Hz ; Publish counter: "<< publish_counter_max);
-
-    //Get the cyberglove version '1', '2' or '3'
-    n_tilde.param("cyberglove_version", cyberglove_version_, std::string("2"));
-    ROS_INFO("Cyberglove version: %s", cyberglove_version_.c_str());
-    
-    //Get the cyberglove joint number '18' or '22'
-    n_tilde.param("cyberglove_joint_number", cyberglove_joint_number_, 22);
-    if (cyberglove_joint_number_ != 22 && cyberglove_joint_number_ != 18)
-    {
-      ROS_FATAL("Cybergloves with %d joints are not supported, use 18 or 22", cyberglove_joint_number_);
-      throw -1;
-    }
-    ROS_INFO("Cyberglove joint number: %d", cyberglove_joint_number_);
-
-    //Get the cyberglove streaming protocol '8bit' or '16bit'
-    n_tilde.param("streaming_protocol", streaming_protocol_, std::string("8bit"));
-    ROS_INFO("Streaming protocol: %s", streaming_protocol_.c_str());
-
-    // set path to glove
-    n_tilde.param("path_to_glove", path_to_glove, std::string("/dev/ttyS0"));
-    ROS_INFO("Opening glove on port: %s", path_to_glove.c_str());
-
-    //initialize the connection with the cyberglove and binds the callback function
-    serial_glove = boost::shared_ptr<CybergloveSerial>(new CybergloveSerial(path_to_glove, cyberglove_version_, cyberglove_joint_number_, streaming_protocol_, boost::bind(&CyberglovePublisher::glove_callback, this, _1, _2)));
-
-    int res = -1;
-    if(cyberglove_version_ == "2")
-    {
-      cyberglove_freq::CybergloveFreq frequency;
-
-      switch( (int)sampling_freq)
-      {
-      case 100:
-        res = serial_glove->set_frequency(frequency.hundred_hz);
-        break;
-      case 45:
-        res = serial_glove->set_frequency(frequency.fourtyfive_hz);
-        break;
-      case 10:
-        res = serial_glove->set_frequency(frequency.ten_hz);
-        break;
-      case 1:
-        res = serial_glove->set_frequency(frequency.one_hz);
-        break;
-      default:
-        res = serial_glove->set_frequency(frequency.hundred_hz);
-        break;
-      }
-
-      //We want the glove to transmit the status (light on/off)
-      res = serial_glove->set_transmit_info(true);
-    }
-    // Should the glove filter the data? (it leads to less smooth movements, but quieter behaviour on the motors)
-    bool filtering;
-    n_tilde.param("filter", filtering, false);
-    std::string filt_msg(filtering?"ON":"OFF");
-    ROS_INFO("Filtering: %s", filt_msg.c_str());
-    res = serial_glove->set_filtering(filtering);
-
-    //publishes calibrated JointState messages
-    std::string prefix;
-    std::string searched_param;
-    n_tilde.searchParam("cyberglove_prefix", searched_param);
-    n_tilde.param(searched_param, prefix, std::string());
-    std::string full_topic = prefix + "/calibrated/joint_states";
-    cyberglove_pub = n_tilde.advertise<sensor_msgs::JointState>(full_topic, 2);
-
-    //publishes raw JointState messages
-    n_tilde.searchParam("cyberglove_prefix", searched_param);
-    n_tilde.param(searched_param, prefix, std::string());
-    full_topic = prefix + "/raw/joint_states";
-    cyberglove_raw_pub = n_tilde.advertise<sensor_msgs::JointState>(full_topic, 2);
-
-    //initialises joint names (the order is important)
-    jointstate_msg.name.push_back("G_ThumbRotate");
-    jointstate_msg.name.push_back("G_ThumbMPJ");
-    jointstate_msg.name.push_back("G_ThumbIJ");
-    jointstate_msg.name.push_back("G_ThumbAb");
-    jointstate_msg.name.push_back("G_IndexMPJ");
-    jointstate_msg.name.push_back("G_IndexPIJ");
-    if (cyberglove_joint_number_ == 22)
-      jointstate_msg.name.push_back("G_IndexDIJ");
-    jointstate_msg.name.push_back("G_MiddleMPJ");
-    jointstate_msg.name.push_back("G_MiddlePIJ");
-    if (cyberglove_joint_number_ == 22)
-      jointstate_msg.name.push_back("G_MiddleDIJ");
-    jointstate_msg.name.push_back("G_MiddleIndexAb");
-    jointstate_msg.name.push_back("G_RingMPJ");
-    jointstate_msg.name.push_back("G_RingPIJ");
-    if (cyberglove_joint_number_ == 22)
-      jointstate_msg.name.push_back("G_RingDIJ");
-    jointstate_msg.name.push_back("G_RingMiddleAb");
-    jointstate_msg.name.push_back("G_PinkieMPJ");
-    jointstate_msg.name.push_back("G_PinkiePIJ");
-    if (cyberglove_joint_number_ == 22)
-      jointstate_msg.name.push_back("G_PinkieDIJ");
-    jointstate_msg.name.push_back("G_PinkieRingAb");
-    jointstate_msg.name.push_back("G_PalmArch");
-    jointstate_msg.name.push_back("G_WristPitch");
-    jointstate_msg.name.push_back("G_WristYaw");
-
-    jointstate_raw_msg.name = jointstate_msg.name;
-
-    //start reading the data.
-    res = serial_glove->start_stream();
+    ROS_FATAL("Cybergloves with %d joints are not supported, use 18 or 22", cyberglove_joint_number_);
+    throw -1;
   }
+  ROS_INFO("Cyberglove joint number: %d", cyberglove_joint_number_);
 
-  CyberglovePublisher::~CyberglovePublisher()
-  {
-  }
+  //Get the cyberglove streaming protocol '8bit' or '16bit'
+  n_tilde.param("streaming_protocol", streaming_protocol_, std::string("8bit"));
+  ROS_INFO("Streaming protocol: %s", streaming_protocol_.c_str());
 
-  void CyberglovePublisher::initialize_calibration(std::string path_to_calibration)
-  {
-    calibration_parser = XmlCalibrationParser(path_to_calibration);
-  }
+  // set path to glove
+  n_tilde.param("path_to_glove", path_to_glove, std::string("/dev/ttyS0"));
+  ROS_INFO("Opening glove on port: %s", path_to_glove.c_str());
 
-  bool CyberglovePublisher::isPublishing()
+  //initialize the connection with the cyberglove and binds the callback function
+  serial_glove = boost::shared_ptr<CybergloveSerial>(new CybergloveSerial(path_to_glove, cyberglove_version_, cyberglove_joint_number_, streaming_protocol_, boost::bind(&CyberglovePublisher::glove_callback, this, _1, _2)));
+
+  int res = -1;
+  if(cyberglove_version_ == "2")
   {
-    if (publishing)
+    cyberglove_freq::CybergloveFreq frequency;
+
+    switch( (int)sampling_freq)
     {
-      return true;
+    case 100:
+      res = serial_glove->set_frequency(frequency.hundred_hz);
+      break;
+    case 45:
+      res = serial_glove->set_frequency(frequency.fourtyfive_hz);
+      break;
+    case 10:
+      res = serial_glove->set_frequency(frequency.ten_hz);
+      break;
+    case 1:
+      res = serial_glove->set_frequency(frequency.one_hz);
+      break;
+    default:
+      res = serial_glove->set_frequency(frequency.hundred_hz);
+      break;
     }
-    else
-    {
-      return false;
-    }
+
+    //We want the glove to transmit the status (light on/off)
+    res = serial_glove->set_transmit_info(true);
   }
+  // Should the glove filter the data? (it leads to less smooth movements, but quieter behaviour on the motors)
+  bool filtering;
+  n_tilde.param("filter", filtering, false);
+  std::string filt_msg(filtering?"ON":"OFF");
+  ROS_INFO("Filtering: %s", filt_msg.c_str());
+  res = serial_glove->set_filtering(filtering);
 
-  void CyberglovePublisher::setPublishing(bool value)
+  //publishes calibrated JointState messages
+  std::string prefix;
+  std::string searched_param;
+  n_tilde.searchParam("cyberglove_prefix", searched_param);
+  n_tilde.param(searched_param, prefix, std::string());
+  std::string full_topic = prefix + "/calibrated/joint_states";
+  cyberglove_pub = n_tilde.advertise<sensor_msgs::JointState>(full_topic, 2);
+
+  //publishes raw JointState messages
+  n_tilde.searchParam("cyberglove_prefix", searched_param);
+  n_tilde.param(searched_param, prefix, std::string());
+  full_topic = prefix + "/raw/joint_states";
+  cyberglove_raw_pub = n_tilde.advertise<sensor_msgs::JointState>(full_topic, 2);
+
+  //initialises joint names (the order is important)
+  jointstate_msg.name.push_back("G_ThumbRotate");
+  jointstate_msg.name.push_back("G_ThumbMPJ");
+  jointstate_msg.name.push_back("G_ThumbIJ");
+  jointstate_msg.name.push_back("G_ThumbAb");
+  jointstate_msg.name.push_back("G_IndexMPJ");
+  jointstate_msg.name.push_back("G_IndexPIJ");
+  if (cyberglove_joint_number_ == 22)
+    jointstate_msg.name.push_back("G_IndexDIJ");
+  jointstate_msg.name.push_back("G_MiddleMPJ");
+  jointstate_msg.name.push_back("G_MiddlePIJ");
+  if (cyberglove_joint_number_ == 22)
+    jointstate_msg.name.push_back("G_MiddleDIJ");
+  jointstate_msg.name.push_back("G_MiddleIndexAb");
+  jointstate_msg.name.push_back("G_RingMPJ");
+  jointstate_msg.name.push_back("G_RingPIJ");
+  if (cyberglove_joint_number_ == 22)
+    jointstate_msg.name.push_back("G_RingDIJ");
+  jointstate_msg.name.push_back("G_RingMiddleAb");
+  jointstate_msg.name.push_back("G_PinkieMPJ");
+  jointstate_msg.name.push_back("G_PinkiePIJ");
+  if (cyberglove_joint_number_ == 22)
+    jointstate_msg.name.push_back("G_PinkieDIJ");
+  jointstate_msg.name.push_back("G_PinkieRingAb");
+  jointstate_msg.name.push_back("G_PalmArch");
+  jointstate_msg.name.push_back("G_WristPitch");
+  jointstate_msg.name.push_back("G_WristYaw");
+
+  jointstate_raw_msg.name = jointstate_msg.name;
+
+  //start reading the data.
+  res = serial_glove->start_stream();
+}
+
+CyberglovePublisher::~CyberglovePublisher()
+{
+}
+
+void CyberglovePublisher::initialize_calibration(std::string path_to_calibration)
+{
+  calibration_parser = XmlCalibrationParser(path_to_calibration);
+}
+
+bool CyberglovePublisher::isPublishing()
+{
+  if (publishing)
   {
-    publishing = value;
+    return true;
   }
-
-  /////////////////////////////////
-  //       CALLBACK METHOD       //
-  /////////////////////////////////
-  void CyberglovePublisher::glove_callback(std::vector<float> glove_pos, bool light_on)
+  else
   {
-    //if the light is off, we don't publish any data.
-    if( !light_on )
-    {
-      publishing = false;
-      ROS_DEBUG("The glove button is off, no data will be read / sent");
-      ros::spinOnce();
-      return;
-    }
-    publishing = true;
+    return false;
+  }
+}
 
-    //appends the current position to the vector of position
-    glove_positions.push_back( glove_pos );
+void CyberglovePublisher::setPublishing(bool value)
+{
+  publishing = value;
+}
 
-    publish_counter_index += 1;
-
-    //if we've enough samples, publish the data:
-    if( publish_counter_index == publish_counter_max )
-    {
-      //reset the messages
-      jointstate_msg.position.clear();
-      jointstate_msg.velocity.clear();
-      jointstate_raw_msg.position.clear();
-      jointstate_raw_msg.velocity.clear();
-      jointstate_raw_msg.header.stamp = ros::Time::now();
-
-      //fill the joint_state msg with the averaged glove data
-      for(unsigned int index_joint = 0; index_joint < cyberglove_joint_number_; ++index_joint)
-      {
-        //compute the average over the samples for the current joint
-        float averaged_value = 0.0f;
-        for (unsigned int index_sample = 0; index_sample < publish_counter_max; ++index_sample)
-        {
-          averaged_value += glove_positions[index_sample][index_joint];
-        }
-        averaged_value /= publish_counter_max;
-
-        jointstate_raw_msg.position.push_back(averaged_value);
-        add_jointstate(averaged_value, jointstate_msg.name[index_joint]);
-      }
-
-      //publish the msgs
-      cyberglove_pub.publish(jointstate_msg);
-      cyberglove_raw_pub.publish(jointstate_raw_msg);
-
-      publish_counter_index = 0;
-      glove_positions.clear();
-    }
-    
+/////////////////////////////////
+//       CALLBACK METHOD       //
+/////////////////////////////////
+void CyberglovePublisher::glove_callback(std::vector<float> glove_pos, bool light_on)
+{
+  //if the light is off, we don't publish any data.
+  if( !light_on )
+  {
+    publishing = false;
+    ROS_DEBUG("The glove button is off, no data will be read / sent");
     ros::spinOnce();
+    return;
   }
+  publishing = true;
 
-  void CyberglovePublisher::add_jointstate(float position, std::string joint_name)
+  //appends the current position to the vector of position
+  glove_positions.push_back( glove_pos );
+
+  publish_counter_index += 1;
+
+  //if we've enough samples, publish the data:
+  if( publish_counter_index == publish_counter_max )
   {
-    //get the calibration value
-    float calibration_value = calibration_parser.get_calibration_value(position, joint_name);
-    //publish the glove position
-    jointstate_msg.position.push_back(calibration_value);
-    //set velocity to 0.
-    //@TODO : send the correct velocity ?
-    jointstate_msg.velocity.push_back(0.0);
+    //reset the messages
+    jointstate_msg.position.clear();
+    jointstate_msg.velocity.clear();
+    jointstate_raw_msg.position.clear();
+    jointstate_raw_msg.velocity.clear();
+    jointstate_raw_msg.header.stamp = ros::Time::now();
+
+    //fill the joint_state msg with the averaged glove data
+    for(unsigned int index_joint = 0; index_joint < cyberglove_joint_number_; ++index_joint)
+    {
+      //compute the average over the samples for the current joint
+      float averaged_value = 0.0f;
+      for (unsigned int index_sample = 0; index_sample < publish_counter_max; ++index_sample)
+      {
+        averaged_value += glove_positions[index_sample][index_joint];
+      }
+      averaged_value /= publish_counter_max;
+
+      jointstate_raw_msg.position.push_back(averaged_value);
+      add_jointstate(averaged_value, jointstate_msg.name[index_joint]);
+    }
+
+    //publish the msgs
+    cyberglove_pub.publish(jointstate_msg);
+    cyberglove_raw_pub.publish(jointstate_raw_msg);
+
+    publish_counter_index = 0;
+    glove_positions.clear();
   }
-}// end namespace
+  
+  ros::spinOnce();
+}
+
+void CyberglovePublisher::add_jointstate(float position, std::string joint_name)
+{
+  //get the calibration value
+  float calibration_value = calibration_parser.get_calibration_value(position, joint_name);
+  //publish the glove position
+  jointstate_msg.position.push_back(calibration_value);
+  //set velocity to 0.
+  //@TODO : send the correct velocity ?
+  jointstate_msg.velocity.push_back(0.0);
+}
+}  // namespace cyberglove
 
 
 

--- a/cyberglove/src/cyberglove_publisher.cpp
+++ b/cyberglove/src/cyberglove_publisher.cpp
@@ -90,7 +90,7 @@ namespace cyberglove{
     ROS_INFO("Opening glove on port: %s", path_to_glove.c_str());
 
     //initialize the connection with the cyberglove and binds the callback function
-    serial_glove = boost::shared_ptr<CybergloveSerial>(new CybergloveSerial(path_to_glove, cyberglove_version_, streaming_protocol_, boost::bind(&CyberglovePublisher::glove_callback, this, _1, _2)));
+    serial_glove = boost::shared_ptr<CybergloveSerial>(new CybergloveSerial(path_to_glove, cyberglove_version_, cyberglove_joint_number_, streaming_protocol_, boost::bind(&CyberglovePublisher::glove_callback, this, _1, _2)));
 
     int res = -1;
     if(cyberglove_version_ == "2")

--- a/cyberglove/src/cyberglove_publisher.cpp
+++ b/cyberglove/src/cyberglove_publisher.cpp
@@ -68,9 +68,18 @@ namespace cyberglove{
     ROS_INFO_STREAM("Sampling at " << sampling_freq << "Hz ; Publishing at "
                     << publish_freq << "Hz ; Publish counter: "<< publish_counter_max);
 
-    //Get the cyberglove version '2' or '3'
+    //Get the cyberglove version '1', '2' or '3'
     n_tilde.param("cyberglove_version", cyberglove_version_, std::string("2"));
     ROS_INFO("Cyberglove version: %s", cyberglove_version_.c_str());
+    
+    //Get the cyberglove joint number '18' or '22'
+    n_tilde.param("cyberglove_joint_number", cyberglove_joint_number_, 22);
+    if (cyberglove_joint_number_ != 22 && cyberglove_joint_number_ != 18)
+    {
+      ROS_FATAL("Cybergloves with %d joints are not supported, use 18 or 22", cyberglove_joint_number_);
+      throw -1;
+    }
+    ROS_INFO("Cyberglove joint number: %d", cyberglove_joint_number_);
 
     //Get the cyberglove streaming protocol '8bit' or '16bit'
     n_tilde.param("streaming_protocol", streaming_protocol_, std::string("8bit"));
@@ -138,18 +147,22 @@ namespace cyberglove{
     jointstate_msg.name.push_back("G_ThumbAb");
     jointstate_msg.name.push_back("G_IndexMPJ");
     jointstate_msg.name.push_back("G_IndexPIJ");
-    jointstate_msg.name.push_back("G_IndexDIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_IndexDIJ");
     jointstate_msg.name.push_back("G_MiddleMPJ");
     jointstate_msg.name.push_back("G_MiddlePIJ");
-    jointstate_msg.name.push_back("G_MiddleDIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_MiddleDIJ");
     jointstate_msg.name.push_back("G_MiddleIndexAb");
     jointstate_msg.name.push_back("G_RingMPJ");
     jointstate_msg.name.push_back("G_RingPIJ");
-    jointstate_msg.name.push_back("G_RingDIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_RingDIJ");
     jointstate_msg.name.push_back("G_RingMiddleAb");
     jointstate_msg.name.push_back("G_PinkieMPJ");
     jointstate_msg.name.push_back("G_PinkiePIJ");
-    jointstate_msg.name.push_back("G_PinkieDIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_PinkieDIJ");
     jointstate_msg.name.push_back("G_PinkieRingAb");
     jointstate_msg.name.push_back("G_PalmArch");
     jointstate_msg.name.push_back("G_WristPitch");
@@ -218,7 +231,7 @@ namespace cyberglove{
       jointstate_raw_msg.header.stamp = ros::Time::now();
 
       //fill the joint_state msg with the averaged glove data
-      for(unsigned int index_joint = 0; index_joint < CybergloveSerial::glove_size; ++index_joint)
+      for(unsigned int index_joint = 0; index_joint < cyberglove_joint_number_; ++index_joint)
       {
         //compute the average over the samples for the current joint
         float averaged_value = 0.0f;

--- a/cyberglove/src/cyberglove_publisher.cpp
+++ b/cyberglove/src/cyberglove_publisher.cpp
@@ -26,36 +26,33 @@
 *
 */
 
-//ROS include
+// ROS include
 #include <ros/ros.h>
 
-//generic C/C++ include
-#include <string>
+// generic C/C++ include
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "cyberglove/cyberglove_publisher.h"
 
-using namespace ros;
-using namespace xml_calibration_parser;
 
-namespace cyberglove{
-
+namespace cyberglove
+{
 /////////////////////////////////
 //    CONSTRUCTOR/DESTRUCTOR   //
 /////////////////////////////////
 
 CyberglovePublisher::CyberglovePublisher()
-  : n_tilde("~"), publish_counter_max(0), publish_counter_index(0),
-    path_to_glove("/dev/ttyS0"), publishing(true)
+  : n_tilde("~"), publish_counter_max(0), publish_counter_index(0), path_to_glove("/dev/ttyS0"), publishing(true)
 {
-
   std::string path_to_calibration;
   n_tilde.param("path_to_calibration", path_to_calibration, std::string("/etc/robot/calibration.d/cyberglove.cal"));
   ROS_INFO("Calibration file loaded for the Cyberglove: %s", path_to_calibration.c_str());
 
   initialize_calibration(path_to_calibration);
 
-  //set sampling frequency
+  // set sampling frequency
   double sampling_freq;
   n_tilde.param("sampling_frequency", sampling_freq, 100.0);
 
@@ -63,25 +60,25 @@ CyberglovePublisher::CyberglovePublisher()
   // before publishing.
   double publish_freq;
   n_tilde.param("publish_frequency", publish_freq, 20.0);
-  publish_counter_max = (int)(sampling_freq / publish_freq);
+  publish_counter_max = static_cast<int>(sampling_freq / publish_freq);
 
-  ROS_INFO_STREAM("Sampling at " << sampling_freq << "Hz ; Publishing at "
-                  << publish_freq << "Hz ; Publish counter: "<< publish_counter_max);
+  ROS_INFO_STREAM("Sampling at " << sampling_freq << "Hz ; Publishing at " << publish_freq
+                                 << "Hz ; Publish counter: " << publish_counter_max);
 
-  //Get the cyberglove version '1', '2' or '3'
+  // Get the cyberglove version '1', '2' or '3'
   n_tilde.param("cyberglove_version", cyberglove_version_, std::string("2"));
   ROS_INFO("Cyberglove version: %s", cyberglove_version_.c_str());
-  
-  //Get the cyberglove joint number '18' or '22'
+
+  // Get the cyberglove joint number '18' or '22'
   n_tilde.param("cyberglove_joint_number", cyberglove_joint_number_, 22);
   if (cyberglove_joint_number_ != 22 && cyberglove_joint_number_ != 18)
   {
     ROS_FATAL("Cybergloves with %d joints are not supported, use 18 or 22", cyberglove_joint_number_);
-    throw -1;
+    throw - 1;
   }
   ROS_INFO("Cyberglove joint number: %d", cyberglove_joint_number_);
 
-  //Get the cyberglove streaming protocol '8bit' or '16bit'
+  // Get the cyberglove streaming protocol '8bit' or '16bit'
   n_tilde.param("streaming_protocol", streaming_protocol_, std::string("8bit"));
   ROS_INFO("Streaming protocol: %s", streaming_protocol_.c_str());
 
@@ -89,44 +86,46 @@ CyberglovePublisher::CyberglovePublisher()
   n_tilde.param("path_to_glove", path_to_glove, std::string("/dev/ttyS0"));
   ROS_INFO("Opening glove on port: %s", path_to_glove.c_str());
 
-  //initialize the connection with the cyberglove and binds the callback function
-  serial_glove = boost::shared_ptr<CybergloveSerial>(new CybergloveSerial(path_to_glove, cyberglove_version_, cyberglove_joint_number_, streaming_protocol_, boost::bind(&CyberglovePublisher::glove_callback, this, _1, _2)));
+  // initialize the connection with the cyberglove and binds the callback function
+  serial_glove = boost::shared_ptr<CybergloveSerial>(
+    new CybergloveSerial(path_to_glove, cyberglove_version_, cyberglove_joint_number_, streaming_protocol_,
+                         boost::bind(&CyberglovePublisher::glove_callback, this, _1, _2)));
 
   int res = -1;
-  if(cyberglove_version_ == "2")
+  if (cyberglove_version_ == "2")
   {
     cyberglove_freq::CybergloveFreq frequency;
 
-    switch( (int)sampling_freq)
+    switch (static_cast<int>(sampling_freq))
     {
-    case 100:
-      res = serial_glove->set_frequency(frequency.hundred_hz);
-      break;
-    case 45:
-      res = serial_glove->set_frequency(frequency.fourtyfive_hz);
-      break;
-    case 10:
-      res = serial_glove->set_frequency(frequency.ten_hz);
-      break;
-    case 1:
-      res = serial_glove->set_frequency(frequency.one_hz);
-      break;
-    default:
-      res = serial_glove->set_frequency(frequency.hundred_hz);
-      break;
+      case 100:
+        res = serial_glove->set_frequency(frequency.hundred_hz);
+        break;
+      case 45:
+        res = serial_glove->set_frequency(frequency.fourtyfive_hz);
+        break;
+      case 10:
+        res = serial_glove->set_frequency(frequency.ten_hz);
+        break;
+      case 1:
+        res = serial_glove->set_frequency(frequency.one_hz);
+        break;
+      default:
+        res = serial_glove->set_frequency(frequency.hundred_hz);
+        break;
     }
 
-    //We want the glove to transmit the status (light on/off)
+    // We want the glove to transmit the status (light on/off)
     res = serial_glove->set_transmit_info(true);
   }
   // Should the glove filter the data? (it leads to less smooth movements, but quieter behaviour on the motors)
   bool filtering;
   n_tilde.param("filter", filtering, false);
-  std::string filt_msg(filtering?"ON":"OFF");
+  std::string filt_msg(filtering ? "ON" : "OFF");
   ROS_INFO("Filtering: %s", filt_msg.c_str());
   res = serial_glove->set_filtering(filtering);
 
-  //publishes calibrated JointState messages
+  // publishes calibrated JointState messages
   std::string prefix;
   std::string searched_param;
   n_tilde.searchParam("cyberglove_prefix", searched_param);
@@ -134,13 +133,13 @@ CyberglovePublisher::CyberglovePublisher()
   std::string full_topic = prefix + "/calibrated/joint_states";
   cyberglove_pub = n_tilde.advertise<sensor_msgs::JointState>(full_topic, 2);
 
-  //publishes raw JointState messages
+  // publishes raw JointState messages
   n_tilde.searchParam("cyberglove_prefix", searched_param);
   n_tilde.param(searched_param, prefix, std::string());
   full_topic = prefix + "/raw/joint_states";
   cyberglove_raw_pub = n_tilde.advertise<sensor_msgs::JointState>(full_topic, 2);
 
-  //initialises joint names (the order is important)
+  // initialises joint names (the order is important)
   jointstate_msg.name.push_back("G_ThumbRotate");
   jointstate_msg.name.push_back("G_ThumbMPJ");
   jointstate_msg.name.push_back("G_ThumbIJ");
@@ -170,7 +169,7 @@ CyberglovePublisher::CyberglovePublisher()
 
   jointstate_raw_msg.name = jointstate_msg.name;
 
-  //start reading the data.
+  // start reading the data.
   res = serial_glove->start_stream();
 }
 
@@ -180,7 +179,7 @@ CyberglovePublisher::~CyberglovePublisher()
 
 void CyberglovePublisher::initialize_calibration(std::string path_to_calibration)
 {
-  calibration_parser = XmlCalibrationParser(path_to_calibration);
+  calibration_parser = xml_calibration_parser::XmlCalibrationParser(path_to_calibration);
 }
 
 bool CyberglovePublisher::isPublishing()
@@ -205,8 +204,8 @@ void CyberglovePublisher::setPublishing(bool value)
 /////////////////////////////////
 void CyberglovePublisher::glove_callback(std::vector<float> glove_pos, bool light_on)
 {
-  //if the light is off, we don't publish any data.
-  if( !light_on )
+  // if the light is off, we don't publish any data.
+  if (!light_on)
   {
     publishing = false;
     ROS_DEBUG("The glove button is off, no data will be read / sent");
@@ -215,25 +214,25 @@ void CyberglovePublisher::glove_callback(std::vector<float> glove_pos, bool ligh
   }
   publishing = true;
 
-  //appends the current position to the vector of position
-  glove_positions.push_back( glove_pos );
+  // appends the current position to the vector of position
+  glove_positions.push_back(glove_pos);
 
   publish_counter_index += 1;
 
-  //if we've enough samples, publish the data:
-  if( publish_counter_index == publish_counter_max )
+  // if we've enough samples, publish the data:
+  if (publish_counter_index == publish_counter_max)
   {
-    //reset the messages
+    // reset the messages
     jointstate_msg.position.clear();
     jointstate_msg.velocity.clear();
     jointstate_raw_msg.position.clear();
     jointstate_raw_msg.velocity.clear();
     jointstate_raw_msg.header.stamp = ros::Time::now();
 
-    //fill the joint_state msg with the averaged glove data
-    for(unsigned int index_joint = 0; index_joint < cyberglove_joint_number_; ++index_joint)
+    // fill the joint_state msg with the averaged glove data
+    for (unsigned int index_joint = 0; index_joint < cyberglove_joint_number_; ++index_joint)
     {
-      //compute the average over the samples for the current joint
+      // compute the average over the samples for the current joint
       float averaged_value = 0.0f;
       for (unsigned int index_sample = 0; index_sample < publish_counter_max; ++index_sample)
       {
@@ -245,30 +244,28 @@ void CyberglovePublisher::glove_callback(std::vector<float> glove_pos, bool ligh
       add_jointstate(averaged_value, jointstate_msg.name[index_joint]);
     }
 
-    //publish the msgs
+    // publish the msgs
     cyberglove_pub.publish(jointstate_msg);
     cyberglove_raw_pub.publish(jointstate_raw_msg);
 
     publish_counter_index = 0;
     glove_positions.clear();
   }
-  
+
   ros::spinOnce();
 }
 
 void CyberglovePublisher::add_jointstate(float position, std::string joint_name)
 {
-  //get the calibration value
+  // get the calibration value
   float calibration_value = calibration_parser.get_calibration_value(position, joint_name);
-  //publish the glove position
+  // publish the glove position
   jointstate_msg.position.push_back(calibration_value);
-  //set velocity to 0.
-  //@TODO : send the correct velocity ?
+  // set velocity to 0.
+  // TODO(shadow) : send the correct velocity ?
   jointstate_msg.velocity.push_back(0.0);
 }
 }  // namespace cyberglove
-
-
 
 /* For the emacs weenies in the crowd.
 Local Variables:

--- a/cyberglove/src/cyberglove_service.cpp
+++ b/cyberglove/src/cyberglove_service.cpp
@@ -35,7 +35,8 @@
 
 using namespace ros;
 
-namespace cyberglove{
+namespace cyberglove
+{
 
 CybergloveService::CybergloveService(boost::shared_ptr<CyberglovePublisher> publish)
  :  node("~"), pub(publish)
@@ -63,4 +64,4 @@ bool CybergloveService::calibration(cyberglove::Calibration::Request &req, cyber
     this->pub->setPublishing(true);
     return true;
 }
-}
+}  // namespace cyberglove

--- a/cyberglove/src/cyberglove_service.cpp
+++ b/cyberglove/src/cyberglove_service.cpp
@@ -27,41 +27,41 @@
 
 #include <ros/ros.h>
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #include "cyberglove/cyberglove_publisher.h"
 #include "cyberglove/cyberglove_service.h"
 
-using namespace ros;
-
 namespace cyberglove
 {
-
-CybergloveService::CybergloveService(boost::shared_ptr<CyberglovePublisher> publish)
- :  node("~"), pub(publish)
+CybergloveService::CybergloveService(boost::shared_ptr<CyberglovePublisher> publish) : node("~"), pub(publish)
 {
-  service_start = node.advertiseService("start",&CybergloveService::start,this);
+  service_start = node.advertiseService("start", &CybergloveService::start, this);
   service_calibration = node.advertiseService("calibration", &CybergloveService::calibration, this);
   ROS_INFO("Listening for service");
 }
 
-bool CybergloveService::start(cyberglove::Start::Request &req, cyberglove::Start::Response &res){
-    if(req.start){
-        ROS_INFO("Glove is now publishing");
-        this->pub->setPublishing(true);
-    }
-    else{
-        ROS_INFO("Glove has stopped publishing");
-        this->pub->setPublishing(false);
-    }
-    //this->pub->cyberglove_pub.shutdown();
-    return true;
-}
-bool CybergloveService::calibration(cyberglove::Calibration::Request &req, cyberglove::Calibration::Response &res){
-    this->pub->setPublishing(false);
-    this->pub->initialize_calibration(req.path);
+bool CybergloveService::start(cyberglove::Start::Request &req, cyberglove::Start::Response &res)
+{
+  if (req.start)
+  {
+    ROS_INFO("Glove is now publishing");
     this->pub->setPublishing(true);
-    return true;
+  }
+  else
+  {
+    ROS_INFO("Glove has stopped publishing");
+    this->pub->setPublishing(false);
+  }
+  // this->pub->cyberglove_pub.shutdown();
+  return true;
+}
+bool CybergloveService::calibration(cyberglove::Calibration::Request &req, cyberglove::Calibration::Response &res)
+{
+  this->pub->setPublishing(false);
+  this->pub->initialize_calibration(req.path);
+  this->pub->setPublishing(true);
+  return true;
 }
 }  // namespace cyberglove

--- a/cyberglove/src/serial_glove.cpp
+++ b/cyberglove/src/serial_glove.cpp
@@ -29,358 +29,358 @@
 
 namespace cyberglove_freq
 {
-  const std::string CybergloveFreq::fastest = "t 1152 0\r"; //fastest speed, just for testing
-  const std::string CybergloveFreq::hundred_hz = "t 1152 1\r"; //100Hz
-  const std::string CybergloveFreq::fourtyfive_hz = "t 2560 1\r"; //45Hz
-  const std::string CybergloveFreq::ten_hz = "t 11520 1\r"; //10Hz
-  const std::string CybergloveFreq::one_hz = "t 57600 2\r"; //1Hz
+const std::string CybergloveFreq::fastest = "t 1152 0\r";        // fastest speed, just for testing
+const std::string CybergloveFreq::hundred_hz = "t 1152 1\r";     // 100Hz
+const std::string CybergloveFreq::fourtyfive_hz = "t 2560 1\r";  // 45Hz
+const std::string CybergloveFreq::ten_hz = "t 11520 1\r";        // 10Hz
+const std::string CybergloveFreq::one_hz = "t 57600 2\r";        // 1Hz
 }
 
 namespace cyberglove
 {
-  const unsigned short CybergloveSerial::timestamp_size = 14;
+const unsigned short CybergloveSerial::timestamp_size = 14;
+
+CybergloveSerial::CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback) :
+  nb_msgs_received(0), glove_pos_index(0), timestamp_bytes_(0), byte_index_(0), glove_size_(glove_size), current_value(0), sensor_value_(0), light_on(true), button_on(true), no_errors(true),
+  cyberglove_version_(cyberglove_version), reception_state_(INITIAL), streaming_protocol_(streaming_protocol)
+{
+  //initialize the vector of positions with 0s
+  for (int i = 0; i < glove_size_; ++i)
+  {
+    glove_positions.push_back(0);
+  }
+
+  //open the serial port
+  cereal_port = boost::shared_ptr<cereal::CerealPort>(new cereal::CerealPort());
+  std::cout << "cereal port created" << std::endl;
+  cereal_port->open(serial_port.c_str());
+
+  //set the callback function
+  callback_function = callback;
+}
+
+CybergloveSerial::~CybergloveSerial()
+{
+  cereal_port->stopStream();
+  //stop the cyberglove transmission
+  cereal_port->write("^c", 2);
+}
+
+int CybergloveSerial::set_filtering(bool value)
+{
+  char aux[30];
+  aux[0] = 'F';
+  if( value ) //Filtering will be on
+  {
+    aux[1] = 0x01;
+    cereal_port->write(aux, 2);
+    std::cout << " - Data filtered" << std::endl;
+  }
+  else // Filtering off
+  {
+    aux[1] = 0x00;
+    cereal_port->write(aux, 2);
+    std::cout << " - Data not filtered" << std::endl;
+  }
+  cereal_port->flush();
+
+  //wait for the command to be applied
+  sleep(1);
+
+  return 0;
+}
+
+int CybergloveSerial::set_transmit_info(bool value)
+{
+  if( value ) //transmit info will be on
+  {
+    cereal_port->write("u 1\r", 4);
+    std::cout << " - Additional info transmitted" << std::endl;
+  }
+  else // transmit info off
+  {
+    cereal_port->write("u 0\r", 4);
+    std::cout << " - Additional info not transmitted" << std::endl;
+  }
+  cereal_port->flush();
+
+  //wait for the command to be applied
+  sleep(1);
+
+  return 0;
+}
+
+int CybergloveSerial::set_frequency(std::string frequency)
+{
+  cereal_port->write(frequency.c_str(), frequency.size());
+  cereal_port->flush();
+
+  //wait for the command to be applied
+  sleep(1);
+  return 0;
+}
+
+int CybergloveSerial::start_stream()
+{
+  std::cout << "starting stream"<<std::endl;
+
+  cereal_port->startReadStream(boost::bind(&CybergloveSerial::stream_callback, this, _1, _2));
+
+  if((cyberglove_version_ == "3") && (streaming_protocol_ == "16bit"))
+  {
+    // enable USB streaming
+    cereal_port->write("1eu", 3);
+    //wait for the command to be applied
+    sleep(1);
+    cereal_port->flush();
+    // start streaming by writing 1S to the serial port
+    cereal_port->write("1S", 2);
+    //wait for the command to be applied
+    sleep(1);
+    cereal_port->flush();
+  }
+  else
+  {
+    //start streaming by writing S to the serial port
+    cereal_port->write("S", 1);
+    //wait for the command to be applied
+    sleep(1);
+    cereal_port->flush();
+  }
+  return 0;
+}
+
+void CybergloveSerial::stream_callback(char* world, int length)
+{
   
-  CybergloveSerial::CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback) :
-    nb_msgs_received(0), glove_pos_index(0), timestamp_bytes_(0), byte_index_(0), glove_size_(glove_size), current_value(0), sensor_value_(0), light_on(true), button_on(true), no_errors(true),
-    cyberglove_version_(cyberglove_version), reception_state_(INITIAL), streaming_protocol_(streaming_protocol)
+  // std::cout << "received " <<(unsigned int)(unsigned char)world[0]<<std::endl;
+  //read each received char.
+  for (int i = 0; i < length; ++i)
   {
-    //initialize the vector of positions with 0s
-    for (int i = 0; i < glove_size_; ++i)
-    {
-      glove_positions.push_back(0);
-    }
-
-    //open the serial port
-    cereal_port = boost::shared_ptr<cereal::CerealPort>(new cereal::CerealPort());
-    std::cout << "cereal port created" << std::endl;
-    cereal_port->open(serial_port.c_str());
-
-    //set the callback function
-    callback_function = callback;
-  }
-
-  CybergloveSerial::~CybergloveSerial()
-  {
-    cereal_port->stopStream();
-    //stop the cyberglove transmission
-    cereal_port->write("^c", 2);
-  }
-
-  int CybergloveSerial::set_filtering(bool value)
-  {
-    char aux[30];
-    aux[0] = 'F';
-    if( value ) //Filtering will be on
-    {
-      aux[1] = 0x01;
-      cereal_port->write(aux, 2);
-      std::cout << " - Data filtered" << std::endl;
-    }
-    else // Filtering off
-    {
-      aux[1] = 0x00;
-      cereal_port->write(aux, 2);
-      std::cout << " - Data not filtered" << std::endl;
-    }
-    cereal_port->flush();
-
-    //wait for the command to be applied
-    sleep(1);
-
-    return 0;
-  }
-
-  int CybergloveSerial::set_transmit_info(bool value)
-  {
-    if( value ) //transmit info will be on
-    {
-      cereal_port->write("u 1\r", 4);
-      std::cout << " - Additional info transmitted" << std::endl;
-    }
-    else // transmit info off
-    {
-      cereal_port->write("u 0\r", 4);
-      std::cout << " - Additional info not transmitted" << std::endl;
-    }
-    cereal_port->flush();
-
-    //wait for the command to be applied
-    sleep(1);
-
-    return 0;
-  }
-
-  int CybergloveSerial::set_frequency(std::string frequency)
-  {
-    cereal_port->write(frequency.c_str(), frequency.size());
-    cereal_port->flush();
-
-    //wait for the command to be applied
-    sleep(1);
-    return 0;
-  }
-
-  int CybergloveSerial::start_stream()
-  {
-    std::cout << "starting stream"<<std::endl;
-
-    cereal_port->startReadStream(boost::bind(&CybergloveSerial::stream_callback, this, _1, _2));
+    current_value = (unsigned int)(unsigned char)world[i];
 
     if((cyberglove_version_ == "3") && (streaming_protocol_ == "16bit"))
     {
-      // enable USB streaming
-      cereal_port->write("1eu", 3);
-      //wait for the command to be applied
-      sleep(1);
-      cereal_port->flush();
-      // start streaming by writing 1S to the serial port
-      cereal_port->write("1S", 2);
-      //wait for the command to be applied
-      sleep(1);
-      cereal_port->flush();
-    }
-    else
-    {
-      //start streaming by writing S to the serial port
-      cereal_port->write("S", 1);
-      //wait for the command to be applied
-      sleep(1);
-      cereal_port->flush();
-    }
-    return 0;
-  }
-
-  void CybergloveSerial::stream_callback(char* world, int length)
-  {
-    
-    // std::cout << "received " <<(unsigned int)(unsigned char)world[0]<<std::endl;
-    //read each received char.
-    for (int i = 0; i < length; ++i)
-    {
-      current_value = (unsigned int)(unsigned char)world[i];
-
-      if((cyberglove_version_ == "3") && (streaming_protocol_ == "16bit"))
-      {
-        char aux[30];
+      char aux[30];
 //        sprintf(aux, "0x%X", current_value);
 //        std::cout << aux << std::endl;
-        switch(reception_state_)
-        {
-          case reception_16bit::SYNCHRONIZATION_1:
-            switch( current_value )
-            {
-              //the data set starts after 0xd 0xa 0x0, it starts with the time + sample index in the format
-              // HH:MM:SS:ss:n'S' where ss is a number from 1 to 30 indicating the index of the sample (if the sampling frequency is 30 Hz)
-              // the n is an index referring to the multiplier index (0-2 if the multiplier is 3)
-              // This is followed by the sensors values (2 bytes per sensor)
-              case 0x0D:
-                reception_state_ = reception_16bit::SYNCHRONIZATION_2;
-                break;
-            }
-            break;
-          case reception_16bit::SYNCHRONIZATION_2:
-            switch( current_value )
-            {
-              case 0x0A:
-                reception_state_ = reception_16bit::SYNCHRONIZATION_3;
-                break;
-              default:
-                reception_state_ = reception_16bit::SYNCHRONIZATION_1;
-                break;
-            }
-            break;
-          case reception_16bit::SYNCHRONIZATION_3:
-            switch( current_value )
-            {
-              case 0x00:
-                timestamp_bytes_ = 0;
-                reception_state_ = reception_16bit::TIMESTAMP;
-                break;
-              default:
-                reception_state_ = reception_16bit::SYNCHRONIZATION_1;
-                break;
-            }
-            break;
-          case reception_16bit::TIMESTAMP:
-            timestamp_bytes_++;
-            // special case observed: sometimes after D A 0 sequence we get n'S' instead of directly the time
-            // another case observed is e1S, so checking for any S coming before time
-            if ((timestamp_bytes_ < timestamp_size) && (current_value == 'S'))
-            {
-              timestamp_bytes_ = 0;
-            }
-            if (timestamp_bytes_ == timestamp_size)
-            {
-              if (current_value == 'S')
-              {
-                ++nb_msgs_received;
-                //reset the index to 0
-                glove_pos_index = 0;
-                byte_index_ = 0;
-                //reset no_errors to true for the new message
-                no_errors = true;
-                reception_state_ = reception_16bit::RECEIVING_FRAME;
-              }
-              else
-              {
-                std::cout << "Sync error. Not an S: Reset frame" << std::endl;
-                reception_state_ = reception_16bit::SYNCHRONIZATION_1;
-              }
-            }
-            break;
-          case reception_16bit::RECEIVING_FRAME:
-            if (byte_index_)
-            {
-              sensor_value_ += current_value;
-              // the values sent by the glove are in the range [1;4094] (12 bit ADC)
-              //   -> we convert them to float in the range [0;1]
-//              char aux[30];
-//              sprintf(aux, "%u", sensor_value_);
-//              std::cout << aux << std::endl;
-              if (sensor_value_ > 0x0FFF)
-              {
-                sprintf(aux, "%u", sensor_value_);
-
-                std::cout << "bad sensor value: " << aux << " Reset frame" << std::endl;
-                reception_state_ = reception_16bit::SYNCHRONIZATION_1;
-                break;
-              }
-
-              glove_positions[glove_pos_index] = (((float)sensor_value_) - 1.0f) / (float)(0x0FFF - 1);
-              ++glove_pos_index;
-              byte_index_ = 0;
-            }
-            else
-            {
-              sensor_value_ = current_value << 8;
-              byte_index_ = 1;
-            }
-            //this is a joint data from the glove
-            //the value in the message should never be 0.
-            if((byte_index_ == 0) && (sensor_value_ == 0))
-            {
-              no_errors = false;
-              std::cout << "error detected" << std::endl;
-            }
-
-            if (glove_pos_index == glove_size_)
-            {
-              if(no_errors)
-                callback_function(glove_positions, true);
-              reception_state_ = reception_16bit::SYNCHRONIZATION_1;
-            }
-            break;
-        }
-      }
-      else
+      switch(reception_state_)
       {
-        switch(reception_state_)
-        {
-          case INITIAL:
-            switch( current_value )
+        case reception_16bit::SYNCHRONIZATION_1:
+          switch( current_value )
+          {
+            //the data set starts after 0xd 0xa 0x0, it starts with the time + sample index in the format
+            // HH:MM:SS:ss:n'S' where ss is a number from 1 to 30 indicating the index of the sample (if the sampling frequency is 30 Hz)
+            // the n is an index referring to the multiplier index (0-2 if the multiplier is 3)
+            // This is followed by the sensors values (2 bytes per sensor)
+            case 0x0D:
+              reception_state_ = reception_16bit::SYNCHRONIZATION_2;
+              break;
+          }
+          break;
+        case reception_16bit::SYNCHRONIZATION_2:
+          switch( current_value )
+          {
+            case 0x0A:
+              reception_state_ = reception_16bit::SYNCHRONIZATION_3;
+              break;
+            default:
+              reception_state_ = reception_16bit::SYNCHRONIZATION_1;
+              break;
+          }
+          break;
+        case reception_16bit::SYNCHRONIZATION_3:
+          switch( current_value )
+          {
+            case 0x00:
+              timestamp_bytes_ = 0;
+              reception_state_ = reception_16bit::TIMESTAMP;
+              break;
+            default:
+              reception_state_ = reception_16bit::SYNCHRONIZATION_1;
+              break;
+          }
+          break;
+        case reception_16bit::TIMESTAMP:
+          timestamp_bytes_++;
+          // special case observed: sometimes after D A 0 sequence we get n'S' instead of directly the time
+          // another case observed is e1S, so checking for any S coming before time
+          if ((timestamp_bytes_ < timestamp_size) && (current_value == 'S'))
+          {
+            timestamp_bytes_ = 0;
+          }
+          if (timestamp_bytes_ == timestamp_size)
+          {
+            if (current_value == 'S')
             {
-            case 'S':
-              //the line starts with S, followed by the sensors values
               ++nb_msgs_received;
               //reset the index to 0
               glove_pos_index = 0;
+              byte_index_ = 0;
               //reset no_errors to true for the new message
               no_errors = true;
-              reception_state_ = RECEIVING_FRAME;
-              break;
-            }
-            break;
-          case RECEIVING_FRAME:
-            //this is a glove sensor value, a status byte or a "message end"
-            if (glove_pos_index < glove_size_) //default
-            {
-              //this is a joint data from the glove
-              //the value in the message should never be 0.
-              if( current_value == 0)
-              {
-                no_errors = false;
-                std::cout << "invalid 0 in the middle of the stream resyncing... (are you sure the number of joint is correct ?) " << std::endl;
-                reception_state_ = INITIAL; 
-              }
-              // the values sent by the glove are in the range [1;254]
-              //   -> we convert them to float in the range [0;1]
-              glove_positions[glove_pos_index] = (((float)current_value) - 1.0f) / 254.0f;            
+              reception_state_ = reception_16bit::RECEIVING_FRAME;
             }
             else
             {
-              if (glove_pos_index == glove_size_)
+              std::cout << "Sync error. Not an S: Reset frame" << std::endl;
+              reception_state_ = reception_16bit::SYNCHRONIZATION_1;
+            }
+          }
+          break;
+        case reception_16bit::RECEIVING_FRAME:
+          if (byte_index_)
+          {
+            sensor_value_ += current_value;
+            // the values sent by the glove are in the range [1;4094] (12 bit ADC)
+            //   -> we convert them to float in the range [0;1]
+//              char aux[30];
+//              sprintf(aux, "%u", sensor_value_);
+//              std::cout << aux << std::endl;
+            if (sensor_value_ > 0x0FFF)
+            {
+              sprintf(aux, "%u", sensor_value_);
+
+              std::cout << "bad sensor value: " << aux << " Reset frame" << std::endl;
+              reception_state_ = reception_16bit::SYNCHRONIZATION_1;
+              break;
+            }
+
+            glove_positions[glove_pos_index] = (((float)sensor_value_) - 1.0f) / (float)(0x0FFF - 1);
+            ++glove_pos_index;
+            byte_index_ = 0;
+          }
+          else
+          {
+            sensor_value_ = current_value << 8;
+            byte_index_ = 1;
+          }
+          //this is a joint data from the glove
+          //the value in the message should never be 0.
+          if((byte_index_ == 0) && (sensor_value_ == 0))
+          {
+            no_errors = false;
+            std::cout << "error detected" << std::endl;
+          }
+
+          if (glove_pos_index == glove_size_)
+          {
+            if(no_errors)
+              callback_function(glove_positions, true);
+            reception_state_ = reception_16bit::SYNCHRONIZATION_1;
+          }
+          break;
+      }
+    }
+    else
+    {
+      switch(reception_state_)
+      {
+        case INITIAL:
+          switch( current_value )
+          {
+          case 'S':
+            //the line starts with S, followed by the sensors values
+            ++nb_msgs_received;
+            //reset the index to 0
+            glove_pos_index = 0;
+            //reset no_errors to true for the new message
+            no_errors = true;
+            reception_state_ = RECEIVING_FRAME;
+            break;
+          }
+          break;
+        case RECEIVING_FRAME:
+          //this is a glove sensor value, a status byte or a "message end"
+          if (glove_pos_index < glove_size_) //default
+          {
+            //this is a joint data from the glove
+            //the value in the message should never be 0.
+            if( current_value == 0)
+            {
+              no_errors = false;
+              std::cout << "invalid 0 in the middle of the stream resyncing... (are you sure the number of joint is correct ?) " << std::endl;
+              reception_state_ = INITIAL; 
+            }
+            // the values sent by the glove are in the range [1;254]
+            //   -> we convert them to float in the range [0;1]
+            glove_positions[glove_pos_index] = (((float)current_value) - 1.0f) / 254.0f;            
+          }
+          else
+          {
+            if (glove_pos_index == glove_size_)
+            {
+              if(cyberglove_version_ == "1")
               {
-                if(cyberglove_version_ == "1")
-                {
-                  // Cyberglove I doesn't provide information on the LED light state
-                  // so we will consider it's always on
-                  light_on = true;
-                  //the last char of the line should be 'S' (83) but this is an assumption not based on documentation
-                  // most of the time we get 83, but other numbers have been observed occasionally
-                  //if it is 83, then the full message has been received,
-                  //and we call the callback function.
-                  if( current_value == 0 && no_errors)
-                    callback_function(glove_positions, light_on);
-                  if( current_value != 0 )
-                    std::cout << "Last char is not 0: " << current_value << std::endl;
-                  reception_state_ = INITIAL;  
-                }
-                else if(cyberglove_version_ == "2")
-                {
-                  //the last char of the msg is the status byte
-
-                  //the status bit 1 corresponds to the button
-                  if(current_value & 2)
-                    button_on = true;
-                  else
-                    button_on = false;
-                  //the status bit 2 corresponds to the light
-                  if(current_value & 4)
-                    light_on = true;
-                  else
-                    light_on = false;
-                }
-                else
-                {
-                  //the last char of the line should be 0
-                  //if it is 0, then the full message has been received,
-                  //and we call the callback function.
-                  if( current_value == 0 && no_errors)
-                    callback_function(glove_positions, light_on);
-                  if( current_value != 0)
-                    std::cout << "Last char is not 0: " << current_value << std::endl;
-
-                  reception_state_ = INITIAL;
-                }
+                // Cyberglove I doesn't provide information on the LED light state
+                // so we will consider it's always on
+                light_on = true;
+                //the last char of the line should be 'S' (83) but this is an assumption not based on documentation
+                // most of the time we get 83, but other numbers have been observed occasionally
+                //if it is 83, then the full message has been received,
+                //and we call the callback function.
+                if( current_value == 0 && no_errors)
+                  callback_function(glove_positions, light_on);
+                if( current_value != 0 )
+                  std::cout << "Last char is not 0: " << current_value << std::endl;
+                reception_state_ = INITIAL;  
               }
-            
-              if (glove_pos_index == glove_size_+1)
+              else if(cyberglove_version_ == "2")
               {
-                if(cyberglove_version_ == "2")
-                {
-                  //the last char of the line should be 0
-                  //if it is 0, then the full message has been received,
-                  //and we call the callback function.
-                  if( current_value == 0 && no_errors)
-                    callback_function(glove_positions, light_on);
-                  if( current_value != 0)
-                    std::cout << "Last char is not 0: " << current_value << std::endl;
-                }
+                //the last char of the msg is the status byte
+
+                //the status bit 1 corresponds to the button
+                if(current_value & 2)
+                  button_on = true;
+                else
+                  button_on = false;
+                //the status bit 2 corresponds to the light
+                if(current_value & 4)
+                  light_on = true;
+                else
+                  light_on = false;
+              }
+              else
+              {
+                //the last char of the line should be 0
+                //if it is 0, then the full message has been received,
+                //and we call the callback function.
+                if( current_value == 0 && no_errors)
+                  callback_function(glove_positions, light_on);
+                if( current_value != 0)
+                  std::cout << "Last char is not 0: " << current_value << std::endl;
+
                 reception_state_ = INITIAL;
               }
             }
-            ++glove_pos_index;
-            break;
-        }
+          
+            if (glove_pos_index == glove_size_+1)
+            {
+              if(cyberglove_version_ == "2")
+              {
+                //the last char of the line should be 0
+                //if it is 0, then the full message has been received,
+                //and we call the callback function.
+                if( current_value == 0 && no_errors)
+                  callback_function(glove_positions, light_on);
+                if( current_value != 0)
+                  std::cout << "Last char is not 0: " << current_value << std::endl;
+              }
+              reception_state_ = INITIAL;
+            }
+          }
+          ++glove_pos_index;
+          break;
       }
     }
   }
-
-  int CybergloveSerial::get_nb_msgs_received()
-  {
-    return nb_msgs_received;
-  }
 }
+
+int CybergloveSerial::get_nb_msgs_received()
+{
+  return nb_msgs_received;
+}
+}  // namespace cyberglove
 
 /* For the emacs weenies in the crowd.
 Local Variables:

--- a/cyberglove/src/serial_glove.cpp
+++ b/cyberglove/src/serial_glove.cpp
@@ -24,8 +24,10 @@
 
 #include "cyberglove/serial_glove.hpp"
 
-#include <iostream>
 #include <cstdio>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace cyberglove_freq
 {
@@ -40,29 +42,42 @@ namespace cyberglove
 {
 const unsigned short CybergloveSerial::timestamp_size = 14;
 
-CybergloveSerial::CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size, std::string streaming_protocol, boost::function<void(std::vector<float>, bool)> callback) :
-  nb_msgs_received(0), glove_pos_index(0), timestamp_bytes_(0), byte_index_(0), glove_size_(glove_size), current_value(0), sensor_value_(0), light_on(true), button_on(true), no_errors(true),
-  cyberglove_version_(cyberglove_version), reception_state_(INITIAL), streaming_protocol_(streaming_protocol)
+CybergloveSerial::CybergloveSerial(std::string serial_port, std::string cyberglove_version, unsigned short glove_size,
+                                   std::string streaming_protocol,
+                                   boost::function<void(std::vector<float>, bool)> callback)
+  : nb_msgs_received(0),
+    glove_pos_index(0),
+    timestamp_bytes_(0),
+    byte_index_(0),
+    glove_size_(glove_size),
+    current_value(0),
+    sensor_value_(0),
+    light_on(true),
+    button_on(true),
+    no_errors(true),
+    cyberglove_version_(cyberglove_version),
+    reception_state_(INITIAL),
+    streaming_protocol_(streaming_protocol)
 {
-  //initialize the vector of positions with 0s
+  // initialize the vector of positions with 0s
   for (int i = 0; i < glove_size_; ++i)
   {
     glove_positions.push_back(0);
   }
 
-  //open the serial port
+  // open the serial port
   cereal_port = boost::shared_ptr<cereal::CerealPort>(new cereal::CerealPort());
   std::cout << "cereal port created" << std::endl;
   cereal_port->open(serial_port.c_str());
 
-  //set the callback function
+  // set the callback function
   callback_function = callback;
 }
 
 CybergloveSerial::~CybergloveSerial()
 {
   cereal_port->stopStream();
-  //stop the cyberglove transmission
+  // stop the cyberglove transmission
   cereal_port->write("^c", 2);
 }
 
@@ -70,13 +85,13 @@ int CybergloveSerial::set_filtering(bool value)
 {
   char aux[30];
   aux[0] = 'F';
-  if( value ) //Filtering will be on
+  if (value)  // Filtering will be on
   {
     aux[1] = 0x01;
     cereal_port->write(aux, 2);
     std::cout << " - Data filtered" << std::endl;
   }
-  else // Filtering off
+  else  // Filtering off
   {
     aux[1] = 0x00;
     cereal_port->write(aux, 2);
@@ -84,7 +99,7 @@ int CybergloveSerial::set_filtering(bool value)
   }
   cereal_port->flush();
 
-  //wait for the command to be applied
+  // wait for the command to be applied
   sleep(1);
 
   return 0;
@@ -92,19 +107,19 @@ int CybergloveSerial::set_filtering(bool value)
 
 int CybergloveSerial::set_transmit_info(bool value)
 {
-  if( value ) //transmit info will be on
+  if (value)  // transmit info will be on
   {
     cereal_port->write("u 1\r", 4);
     std::cout << " - Additional info transmitted" << std::endl;
   }
-  else // transmit info off
+  else  // transmit info off
   {
     cereal_port->write("u 0\r", 4);
     std::cout << " - Additional info not transmitted" << std::endl;
   }
   cereal_port->flush();
 
-  //wait for the command to be applied
+  // wait for the command to be applied
   sleep(1);
 
   return 0;
@@ -115,35 +130,35 @@ int CybergloveSerial::set_frequency(std::string frequency)
   cereal_port->write(frequency.c_str(), frequency.size());
   cereal_port->flush();
 
-  //wait for the command to be applied
+  // wait for the command to be applied
   sleep(1);
   return 0;
 }
 
 int CybergloveSerial::start_stream()
 {
-  std::cout << "starting stream"<<std::endl;
+  std::cout << "starting stream" << std::endl;
 
   cereal_port->startReadStream(boost::bind(&CybergloveSerial::stream_callback, this, _1, _2));
 
-  if((cyberglove_version_ == "3") && (streaming_protocol_ == "16bit"))
+  if ((cyberglove_version_ == "3") && (streaming_protocol_ == "16bit"))
   {
     // enable USB streaming
     cereal_port->write("1eu", 3);
-    //wait for the command to be applied
+    // wait for the command to be applied
     sleep(1);
     cereal_port->flush();
     // start streaming by writing 1S to the serial port
     cereal_port->write("1S", 2);
-    //wait for the command to be applied
+    // wait for the command to be applied
     sleep(1);
     cereal_port->flush();
   }
   else
   {
-    //start streaming by writing S to the serial port
+    // start streaming by writing S to the serial port
     cereal_port->write("S", 1);
-    //wait for the command to be applied
+    // wait for the command to be applied
     sleep(1);
     cereal_port->flush();
   }
@@ -152,25 +167,25 @@ int CybergloveSerial::start_stream()
 
 void CybergloveSerial::stream_callback(char* world, int length)
 {
-  
   // std::cout << "received " <<(unsigned int)(unsigned char)world[0]<<std::endl;
-  //read each received char.
+  // read each received char.
   for (int i = 0; i < length; ++i)
   {
     current_value = (unsigned int)(unsigned char)world[i];
 
-    if((cyberglove_version_ == "3") && (streaming_protocol_ == "16bit"))
+    if ((cyberglove_version_ == "3") && (streaming_protocol_ == "16bit"))
     {
       char aux[30];
-//        sprintf(aux, "0x%X", current_value);
-//        std::cout << aux << std::endl;
-      switch(reception_state_)
+      //        sprintf(aux, "0x%X", current_value);
+      //        std::cout << aux << std::endl;
+      switch (reception_state_)
       {
         case reception_16bit::SYNCHRONIZATION_1:
-          switch( current_value )
+          switch (current_value)
           {
-            //the data set starts after 0xd 0xa 0x0, it starts with the time + sample index in the format
-            // HH:MM:SS:ss:n'S' where ss is a number from 1 to 30 indicating the index of the sample (if the sampling frequency is 30 Hz)
+            // the data set starts after 0xd 0xa 0x0, it starts with the time + sample index in the format
+            // HH:MM:SS:ss:n'S' where ss is a number from 1 to 30 indicating the index of the sample (if the sampling
+            // frequency is 30 Hz)
             // the n is an index referring to the multiplier index (0-2 if the multiplier is 3)
             // This is followed by the sensors values (2 bytes per sensor)
             case 0x0D:
@@ -179,7 +194,7 @@ void CybergloveSerial::stream_callback(char* world, int length)
           }
           break;
         case reception_16bit::SYNCHRONIZATION_2:
-          switch( current_value )
+          switch (current_value)
           {
             case 0x0A:
               reception_state_ = reception_16bit::SYNCHRONIZATION_3;
@@ -190,7 +205,7 @@ void CybergloveSerial::stream_callback(char* world, int length)
           }
           break;
         case reception_16bit::SYNCHRONIZATION_3:
-          switch( current_value )
+          switch (current_value)
           {
             case 0x00:
               timestamp_bytes_ = 0;
@@ -214,10 +229,10 @@ void CybergloveSerial::stream_callback(char* world, int length)
             if (current_value == 'S')
             {
               ++nb_msgs_received;
-              //reset the index to 0
+              // reset the index to 0
               glove_pos_index = 0;
               byte_index_ = 0;
-              //reset no_errors to true for the new message
+              // reset no_errors to true for the new message
               no_errors = true;
               reception_state_ = reception_16bit::RECEIVING_FRAME;
             }
@@ -234,19 +249,20 @@ void CybergloveSerial::stream_callback(char* world, int length)
             sensor_value_ += current_value;
             // the values sent by the glove are in the range [1;4094] (12 bit ADC)
             //   -> we convert them to float in the range [0;1]
-//              char aux[30];
-//              sprintf(aux, "%u", sensor_value_);
-//              std::cout << aux << std::endl;
+            //              char aux[30];
+            //              sprintf(aux, "%u", sensor_value_);
+            //              std::cout << aux << std::endl;
             if (sensor_value_ > 0x0FFF)
             {
-              sprintf(aux, "%u", sensor_value_);
+              snprintf(aux, sizeof(aux), "%u", sensor_value_);
 
               std::cout << "bad sensor value: " << aux << " Reset frame" << std::endl;
               reception_state_ = reception_16bit::SYNCHRONIZATION_1;
               break;
             }
 
-            glove_positions[glove_pos_index] = (((float)sensor_value_) - 1.0f) / (float)(0x0FFF - 1);
+            glove_positions[glove_pos_index] = ((static_cast<float>(sensor_value_)) - 1.0f) /
+                                               static_cast<float>(0x0FFF - 1);
             ++glove_pos_index;
             byte_index_ = 0;
           }
@@ -255,9 +271,9 @@ void CybergloveSerial::stream_callback(char* world, int length)
             sensor_value_ = current_value << 8;
             byte_index_ = 1;
           }
-          //this is a joint data from the glove
-          //the value in the message should never be 0.
-          if((byte_index_ == 0) && (sensor_value_ == 0))
+          // this is a joint data from the glove
+          // the value in the message should never be 0.
+          if ((byte_index_ == 0) && (sensor_value_ == 0))
           {
             no_errors = false;
             std::cout << "error detected" << std::endl;
@@ -265,7 +281,7 @@ void CybergloveSerial::stream_callback(char* world, int length)
 
           if (glove_pos_index == glove_size_)
           {
-            if(no_errors)
+            if (no_errors)
               callback_function(glove_positions, true);
             reception_state_ = reception_16bit::SYNCHRONIZATION_1;
           }
@@ -274,96 +290,98 @@ void CybergloveSerial::stream_callback(char* world, int length)
     }
     else
     {
-      switch(reception_state_)
+      switch (reception_state_)
       {
         case INITIAL:
-          switch( current_value )
+          switch (current_value)
           {
-          case 'S':
-            //the line starts with S, followed by the sensors values
-            ++nb_msgs_received;
-            //reset the index to 0
-            glove_pos_index = 0;
-            //reset no_errors to true for the new message
-            no_errors = true;
-            reception_state_ = RECEIVING_FRAME;
-            break;
+            case 'S':
+              // the line starts with S, followed by the sensors values
+              ++nb_msgs_received;
+              // reset the index to 0
+              glove_pos_index = 0;
+              // reset no_errors to true for the new message
+              no_errors = true;
+              reception_state_ = RECEIVING_FRAME;
+              break;
           }
           break;
         case RECEIVING_FRAME:
-          //this is a glove sensor value, a status byte or a "message end"
-          if (glove_pos_index < glove_size_) //default
+          // this is a glove sensor value, a status byte or a "message end"
+          if (glove_pos_index < glove_size_)  // default
           {
-            //this is a joint data from the glove
-            //the value in the message should never be 0.
-            if( current_value == 0)
+            // this is a joint data from the glove
+            // the value in the message should never be 0.
+            if (current_value == 0)
             {
               no_errors = false;
-              std::cout << "invalid 0 in the middle of the stream resyncing... (are you sure the number of joint is correct ?) " << std::endl;
-              reception_state_ = INITIAL; 
+              std::cout << "invalid 0 in the middle of the stream resyncing... (are you sure the number of joint is "
+                           "correct ?) "
+                        << std::endl;
+              reception_state_ = INITIAL;
             }
             // the values sent by the glove are in the range [1;254]
             //   -> we convert them to float in the range [0;1]
-            glove_positions[glove_pos_index] = (((float)current_value) - 1.0f) / 254.0f;            
+            glove_positions[glove_pos_index] = ((static_cast<float>(current_value)) - 1.0f) / 254.0f;
           }
           else
           {
             if (glove_pos_index == glove_size_)
             {
-              if(cyberglove_version_ == "1")
+              if (cyberglove_version_ == "1")
               {
                 // Cyberglove I doesn't provide information on the LED light state
                 // so we will consider it's always on
                 light_on = true;
-                //the last char of the line should be 'S' (83) but this is an assumption not based on documentation
+                // the last char of the line should be 'S' (83) but this is an assumption not based on documentation
                 // most of the time we get 83, but other numbers have been observed occasionally
-                //if it is 83, then the full message has been received,
-                //and we call the callback function.
-                if( current_value == 0 && no_errors)
+                // if it is 83, then the full message has been received,
+                // and we call the callback function.
+                if (current_value == 0 && no_errors)
                   callback_function(glove_positions, light_on);
-                if( current_value != 0 )
+                if (current_value != 0)
                   std::cout << "Last char is not 0: " << current_value << std::endl;
-                reception_state_ = INITIAL;  
+                reception_state_ = INITIAL;
               }
-              else if(cyberglove_version_ == "2")
+              else if (cyberglove_version_ == "2")
               {
-                //the last char of the msg is the status byte
+                // the last char of the msg is the status byte
 
-                //the status bit 1 corresponds to the button
-                if(current_value & 2)
+                // the status bit 1 corresponds to the button
+                if (current_value & 2)
                   button_on = true;
                 else
                   button_on = false;
-                //the status bit 2 corresponds to the light
-                if(current_value & 4)
+                // the status bit 2 corresponds to the light
+                if (current_value & 4)
                   light_on = true;
                 else
                   light_on = false;
               }
               else
               {
-                //the last char of the line should be 0
-                //if it is 0, then the full message has been received,
-                //and we call the callback function.
-                if( current_value == 0 && no_errors)
+                // the last char of the line should be 0
+                // if it is 0, then the full message has been received,
+                // and we call the callback function.
+                if (current_value == 0 && no_errors)
                   callback_function(glove_positions, light_on);
-                if( current_value != 0)
+                if (current_value != 0)
                   std::cout << "Last char is not 0: " << current_value << std::endl;
 
                 reception_state_ = INITIAL;
               }
             }
-          
-            if (glove_pos_index == glove_size_+1)
+
+            if (glove_pos_index == glove_size_ + 1)
             {
-              if(cyberglove_version_ == "2")
+              if (cyberglove_version_ == "2")
               {
-                //the last char of the line should be 0
-                //if it is 0, then the full message has been received,
-                //and we call the callback function.
-                if( current_value == 0 && no_errors)
+                // the last char of the line should be 0
+                // if it is 0, then the full message has been received,
+                // and we call the callback function.
+                if (current_value == 0 && no_errors)
                   callback_function(glove_positions, light_on);
-                if( current_value != 0)
+                if (current_value != 0)
                   std::cout << "Last char is not 0: " << current_value << std::endl;
               }
               reception_state_ = INITIAL;

--- a/cyberglove/src/serial_glove.cpp
+++ b/cyberglove/src/serial_glove.cpp
@@ -130,15 +130,21 @@ namespace cyberglove
     {
       // enable USB streaming
       cereal_port->write("1eu", 3);
+      //wait for the command to be applied
+      sleep(1);
       cereal_port->flush();
       // start streaming by writing 1S to the serial port
       cereal_port->write("1S", 2);
+      //wait for the command to be applied
+      sleep(1);
       cereal_port->flush();
     }
     else
     {
       //start streaming by writing S to the serial port
       cereal_port->write("S", 1);
+      //wait for the command to be applied
+      sleep(1);
       cereal_port->flush();
     }
 

--- a/cyberglove/src/xml_calibration_parser.cpp
+++ b/cyberglove/src/xml_calibration_parser.cpp
@@ -44,281 +44,282 @@
 #include <string>
 #include <sstream>
 
-namespace xml_calibration_parser{
+namespace xml_calibration_parser
+{
 
-  const float XmlCalibrationParser::lookup_precision = 1000.0f;
-  const float XmlCalibrationParser::lookup_offset = 1.0f;
+const float XmlCalibrationParser::lookup_precision = 1000.0f;
+const float XmlCalibrationParser::lookup_offset = 1.0f;
 
-  /**
-   * The constructor: parses the given file and stores the calibration
-   * in the vector std::vector<JointCalibration> jointsCalibrations.
-   *
-   * @param path_to_calibration the path to the xml calibration
-   * file. Please note that it is best to use ros parameters to set
-   * the path in your code calling this constructor.
-   */
-  XmlCalibrationParser::XmlCalibrationParser(std::string path_to_calibration)
-  {
-    TiXmlDocument doc(path_to_calibration.c_str());
-    bool loadOkay = doc.LoadFile();
-    if (loadOkay)
-      {
-	ROS_DEBUG("loading calibration %s", path_to_calibration.c_str());
-	parse_calibration_file( doc.RootElement() );
-
-	build_calibration_table();
-      }
-    else
-      {
-	ROS_ERROR("Failed to load file \"%s\"", path_to_calibration.c_str());
-      }
-  }
-
-  /**
-   * Parses the calibration file and retreive the full calibration for
-   * the cyberglove.
-   *
-   * @param pParent The parent node (Cyberglove_calibration)
-   * containing all the xml tree.
-   */
-  void XmlCalibrationParser::parse_calibration_file( TiXmlNode* pParent )
-  {
-    if ( !pParent ) return;
-
-    TiXmlElement* child = pParent->FirstChildElement("Joint");
-
-    //no Joint elements => error
-    if( !child )
-      {
-	ROS_ERROR( "The calibration file seems to be broken: there's no Joint elements." );
-	return;
-      }
-
-    bool has_sibling = true;
-    while( has_sibling )
-      {
-	// a Joint element was found
-	XmlCalibrationParser::JointCalibration joint_calib;
-	joint_calib.name = child->Attribute("name");
-
-	joint_calib.calibrations = parse_joint_attributes(child);
-
-	jointsCalibrations.push_back(joint_calib);
-
-	//get the next Joint element
-	child = child->NextSiblingElement("Joint");
-	//no more Joint elements => stop
-	if( !child )
-	    has_sibling = false;
-      }
-  }
-
-  /**
-   * Parses the Joint element of the calibration file.
-   *
-   * @param pParent a Joint element
-   *
-   * @return the calibration values for this Joint.
-   */
-  std::vector<XmlCalibrationParser::Calibration>
-  XmlCalibrationParser::parse_joint_attributes( TiXmlNode* pParent )
-  {
-    std::vector<XmlCalibrationParser::Calibration> calibrations;
-
-    TiXmlElement* child = pParent->FirstChildElement("calib");
-
-    //no Joint elements => error
-    if( !child )
-      {
-	ROS_ERROR( "The calibration file seems to be broken: there's no calibration elements." );
-	return calibrations;
-      }
-    bool has_sibling = true;
-
-    while( has_sibling )
-      {
-	// a Joint element was found
-	XmlCalibrationParser::Calibration calib;
-	float fval;
-
-	// get the raw-value
-	if( child->QueryFloatAttribute("raw_value", &fval) == TIXML_SUCCESS )
-	  calib.raw_value = fval;
-	else
-	  ROS_ERROR("The calibration file seems to be broken: there's no raw_value attribute.");
-
-	//get the calibrated-value
-	if( child->QueryFloatAttribute("calibrated_value", &fval) == TIXML_SUCCESS )
-	  calib.calibrated_value = fval;
-	else
-	  ROS_ERROR("The calibration file seems to be broken: there's no calibrated_value attribute.");
-
-	//add the calibration to the vector
-	calibrations.push_back( calib );
-
-	//get the next Joint element
-	child = child->NextSiblingElement("calib");
-	//no more Joint elements => stop
-	if( !child )
-	    has_sibling = false;
-      }
-
-    return calibrations;
-  }
-
-
-  /**
-   * Transform the calibration values to a lookup table for fast
-   * processing of the calibration process.
-   * NB: the lookup table ranges from 0 to +lookup_offset
-   * with a precision of 1/lookup_precision.
-   *
-   */
-  int XmlCalibrationParser::build_calibration_table()
-  {
-    std::ostringstream ss;
-    for (unsigned int index_calib = 0; index_calib < jointsCalibrations.size(); ++index_calib)
+/**
+ * The constructor: parses the given file and stores the calibration
+ * in the vector std::vector<JointCalibration> jointsCalibrations.
+ *
+ * @param path_to_calibration the path to the xml calibration
+ * file. Please note that it is best to use ros parameters to set
+ * the path in your code calling this constructor.
+ */
+XmlCalibrationParser::XmlCalibrationParser(std::string path_to_calibration)
+{
+  TiXmlDocument doc(path_to_calibration.c_str());
+  bool loadOkay = doc.LoadFile();
+  if (loadOkay)
     {
-      std::string name = jointsCalibrations[index_calib].name;
-      ROS_DEBUG_STREAM(name);
+ROS_DEBUG("loading calibration %s", path_to_calibration.c_str());
+parse_calibration_file( doc.RootElement() );
 
-      std::vector<Calibration> calib = jointsCalibrations[index_calib].calibrations;
-
-      std::vector<float> lookup_table((int)lookup_offset*(int)lookup_precision);
-
-      if( calib.size() < 2 )
-        ROS_ERROR("Not enough points were defined to set up the calibration.");
-
-      //order the calibration vector by ascending values of raw_value
-      //      ROS_ERROR("TODO: calibration vector not ordered yet");
-
-      ss << "lookup table : ";
-
-      //setup the lookup table
-      for( unsigned int index_lookup = 0;
-           index_lookup < lookup_table.size() ;
-           ++ index_lookup )
-      {
-        float value = compute_lookup_value(index_lookup, calib);
-        ss << index_lookup<<":"<<value << " ";
-        lookup_table[index_lookup] = value;
-      }
-
-      ss << std::endl;
-
-      //add the values to the map
-      joints_calibrations_map[name] = lookup_table;
-      //joints_calibrations_map.insert(std::pair <std::string, std::vector<float> >(name, lookup_table));
+build_calibration_table();
     }
-    ROS_DEBUG_STREAM(ss);
-    return 0;
-  }
+  else
+    {
+ROS_ERROR("Failed to load file \"%s\"", path_to_calibration.c_str());
+    }
+}
 
-  /**
-   * return the value to store in the lookup table for a given index,
-   * using the calibration information.
-   *
-   * @param index the index for which we compute the value
-   *
-   * @param calib the vector containing the calibration informations
-   * (a list of raw_value <=> calibrated_value)
-   *
-   * @return the value to be stored in the lookup table
-   */
-  float XmlCalibrationParser::compute_lookup_value(int index, std::vector<XmlCalibrationParser::Calibration> calib)
+/**
+ * Parses the calibration file and retreive the full calibration for
+ * the cyberglove.
+ *
+ * @param pParent The parent node (Cyberglove_calibration)
+ * containing all the xml tree.
+ */
+void XmlCalibrationParser::parse_calibration_file( TiXmlNode* pParent )
+{
+  if ( !pParent ) return;
+
+  TiXmlElement* child = pParent->FirstChildElement("Joint");
+
+  //no Joint elements => error
+  if( !child )
+    {
+ROS_ERROR( "The calibration file seems to be broken: there's no Joint elements." );
+return;
+    }
+
+  bool has_sibling = true;
+  while( has_sibling )
+    {
+// a Joint element was found
+XmlCalibrationParser::JointCalibration joint_calib;
+joint_calib.name = child->Attribute("name");
+
+joint_calib.calibrations = parse_joint_attributes(child);
+
+jointsCalibrations.push_back(joint_calib);
+
+//get the next Joint element
+child = child->NextSiblingElement("Joint");
+//no more Joint elements => stop
+if( !child )
+    has_sibling = false;
+    }
+}
+
+/**
+ * Parses the Joint element of the calibration file.
+ *
+ * @param pParent a Joint element
+ *
+ * @return the calibration values for this Joint.
+ */
+std::vector<XmlCalibrationParser::Calibration>
+XmlCalibrationParser::parse_joint_attributes( TiXmlNode* pParent )
+{
+  std::vector<XmlCalibrationParser::Calibration> calibrations;
+
+  TiXmlElement* child = pParent->FirstChildElement("calib");
+
+  //no Joint elements => error
+  if( !child )
+    {
+ROS_ERROR( "The calibration file seems to be broken: there's no calibration elements." );
+return calibrations;
+    }
+  bool has_sibling = true;
+
+  while( has_sibling )
+    {
+// a Joint element was found
+XmlCalibrationParser::Calibration calib;
+float fval;
+
+// get the raw-value
+if( child->QueryFloatAttribute("raw_value", &fval) == TIXML_SUCCESS )
+  calib.raw_value = fval;
+else
+  ROS_ERROR("The calibration file seems to be broken: there's no raw_value attribute.");
+
+//get the calibrated-value
+if( child->QueryFloatAttribute("calibrated_value", &fval) == TIXML_SUCCESS )
+  calib.calibrated_value = fval;
+else
+  ROS_ERROR("The calibration file seems to be broken: there's no calibrated_value attribute.");
+
+//add the calibration to the vector
+calibrations.push_back( calib );
+
+//get the next Joint element
+child = child->NextSiblingElement("calib");
+//no more Joint elements => stop
+if( !child )
+    has_sibling = false;
+    }
+
+  return calibrations;
+}
+
+
+/**
+ * Transform the calibration values to a lookup table for fast
+ * processing of the calibration process.
+ * NB: the lookup table ranges from 0 to +lookup_offset
+ * with a precision of 1/lookup_precision.
+ *
+ */
+int XmlCalibrationParser::build_calibration_table()
+{
+  std::ostringstream ss;
+  for (unsigned int index_calib = 0; index_calib < jointsCalibrations.size(); ++index_calib)
   {
-    float raw_pos = return_raw_position_from_index(index);
+    std::string name = jointsCalibrations[index_calib].name;
+    ROS_DEBUG_STREAM(name);
 
-    if(calib.size() == 2)
-      return linear_interpolate( raw_pos,
-				 calib[0].raw_value,
-				 calib[0].calibrated_value,
-				 calib[1].raw_value,
-				 calib[1].calibrated_value
-			     );
+    std::vector<Calibration> calib = jointsCalibrations[index_calib].calibrations;
 
+    std::vector<float> lookup_table((int)lookup_offset*(int)lookup_precision);
 
-    for( unsigned int index_calib = 0; index_calib < calib.size() - 1;
-	 ++index_calib)
-      {
-	if(calib[index_calib].raw_value > raw_pos)
-	  {
-	    return linear_interpolate( raw_pos,
-				       calib[index_calib].raw_value,
-				       calib[index_calib].calibrated_value,
-				       calib[index_calib+1].raw_value,
-				       calib[index_calib+1].calibrated_value
-				     );
-	  }
-      }
+    if( calib.size() < 2 )
+      ROS_ERROR("Not enough points were defined to set up the calibration.");
 
-    //bigger than last calibrated value => extrapolate the value from
-    //last 2 values
-    //TODO: ca marche la formule si on est en dehors des points ? oui
+    //order the calibration vector by ascending values of raw_value
+    //      ROS_ERROR("TODO: calibration vector not ordered yet");
+
+    ss << "lookup table : ";
+
+    //setup the lookup table
+    for( unsigned int index_lookup = 0;
+         index_lookup < lookup_table.size() ;
+         ++ index_lookup )
+    {
+      float value = compute_lookup_value(index_lookup, calib);
+      ss << index_lookup<<":"<<value << " ";
+      lookup_table[index_lookup] = value;
+    }
+
+    ss << std::endl;
+
+    //add the values to the map
+    joints_calibrations_map[name] = lookup_table;
+    //joints_calibrations_map.insert(std::pair <std::string, std::vector<float> >(name, lookup_table));
+  }
+  ROS_DEBUG_STREAM(ss);
+  return 0;
+}
+
+/**
+ * return the value to store in the lookup table for a given index,
+ * using the calibration information.
+ *
+ * @param index the index for which we compute the value
+ *
+ * @param calib the vector containing the calibration informations
+ * (a list of raw_value <=> calibrated_value)
+ *
+ * @return the value to be stored in the lookup table
+ */
+float XmlCalibrationParser::compute_lookup_value(int index, std::vector<XmlCalibrationParser::Calibration> calib)
+{
+  float raw_pos = return_raw_position_from_index(index);
+
+  if(calib.size() == 2)
     return linear_interpolate( raw_pos,
-			       calib[calib.size()-1].raw_value,
-			       calib[calib.size()-1].calibrated_value,
-			       calib[calib.size()].raw_value,
-			       calib[calib.size()].calibrated_value
-			     );
+       calib[0].raw_value,
+       calib[0].calibrated_value,
+       calib[1].raw_value,
+       calib[1].calibrated_value
+         );
 
-  }
 
-  float XmlCalibrationParser::get_calibration_value(float position, std::string joint_name)
+  for( unsigned int index_calib = 0; index_calib < calib.size() - 1;
+ ++index_calib)
+    {
+if(calib[index_calib].raw_value > raw_pos)
   {
-    mapType::iterator iter = joints_calibrations_map.find(joint_name);
-
-    if( iter != joints_calibrations_map.end() )
-      {
-	//reads from the lookup table
-	int index = return_index_from_raw_position(position);
-	//std::cout << index << std::endl;
-	return iter->second[index];
-      }
-    else
-      {
-	ROS_ERROR("%s is not calibrated", joint_name.c_str());
-	return 1.0f;
-      }
+    return linear_interpolate( raw_pos,
+             calib[index_calib].raw_value,
+             calib[index_calib].calibrated_value,
+             calib[index_calib+1].raw_value,
+             calib[index_calib+1].calibrated_value
+           );
   }
+    }
 
-  float XmlCalibrationParser::linear_interpolate( float x ,
-						  float x0, float y0,
-						  float x1, float y1 )
-  {
+  //bigger than last calibrated value => extrapolate the value from
+  //last 2 values
+  //TODO: ca marche la formule si on est en dehors des points ? oui
+  return linear_interpolate( raw_pos,
+           calib[calib.size()-1].raw_value,
+           calib[calib.size()-1].calibrated_value,
+           calib[calib.size()].raw_value,
+           calib[calib.size()].calibrated_value
+         );
 
-    //TODO ca marche qd c'est decroissant ca? oui
-    float y = 0.0f;
-    if( x1 - x0 == 0.0f )
-      {
-	ROS_WARN("Bad calibration: raw_calib[1] = raw_calib[0]");
-	return 0.0f;
-      }
+}
 
-    y = y0 + (x-x0)* ((y1-y0)/(x1-x0));
-    return y;
-  }
+float XmlCalibrationParser::get_calibration_value(float position, std::string joint_name)
+{
+  mapType::iterator iter = joints_calibrations_map.find(joint_name);
+
+  if( iter != joints_calibrations_map.end() )
+    {
+//reads from the lookup table
+int index = return_index_from_raw_position(position);
+//std::cout << index << std::endl;
+return iter->second[index];
+    }
+  else
+    {
+ROS_ERROR("%s is not calibrated", joint_name.c_str());
+return 1.0f;
+    }
+}
+
+float XmlCalibrationParser::linear_interpolate( float x ,
+            float x0, float y0,
+            float x1, float y1 )
+{
+
+  //TODO ca marche qd c'est decroissant ca? oui
+  float y = 0.0f;
+  if( x1 - x0 == 0.0f )
+    {
+ROS_WARN("Bad calibration: raw_calib[1] = raw_calib[0]");
+return 0.0f;
+    }
+
+  y = y0 + (x-x0)* ((y1-y0)/(x1-x0));
+  return y;
+}
 
 
-  int XmlCalibrationParser::return_index_from_raw_position(float raw_position)
-  {
-    if (raw_position < 0.0f)
-      return 0;
-    if(raw_position > 1.0f)
-      return lookup_precision;
-    return round(raw_position * lookup_precision);
-  };
+int XmlCalibrationParser::return_index_from_raw_position(float raw_position)
+{
+  if (raw_position < 0.0f)
+    return 0;
+  if(raw_position > 1.0f)
+    return lookup_precision;
+  return round(raw_position * lookup_precision);
+};
 
-  int XmlCalibrationParser::round(float number)
-  {
-    //we only have positive numbers
-    return (int)floor(number + 0.5);
-    //return number < 0.0 ? ceil(number - 0.5) : floor(number + 0.5);
-  }
+int XmlCalibrationParser::round(float number)
+{
+  //we only have positive numbers
+  return (int)floor(number + 0.5);
+  //return number < 0.0 ? ceil(number - 0.5) : floor(number + 0.5);
+}
 
 
-  std::vector<XmlCalibrationParser::JointCalibration> XmlCalibrationParser::getJointsCalibrations()
-  {
-    return jointsCalibrations;
-  }
-}//end namespace
+std::vector<XmlCalibrationParser::JointCalibration> XmlCalibrationParser::getJointsCalibrations()
+{
+  return jointsCalibrations;
+}
+}  // namespace xml_calibration_parser

--- a/cyberglove/src/xml_calibration_parser.cpp
+++ b/cyberglove/src/xml_calibration_parser.cpp
@@ -40,7 +40,9 @@
 
 #include "cyberglove/xml_calibration_parser.h"
 
-#include <stdio.h>
+#include <cstdio>
+#include <string>
+#include <sstream>
 
 namespace xml_calibration_parser{
 
@@ -174,40 +176,41 @@ namespace xml_calibration_parser{
    */
   int XmlCalibrationParser::build_calibration_table()
   {
+    std::ostringstream ss;
     for (unsigned int index_calib = 0; index_calib < jointsCalibrations.size(); ++index_calib)
     {
       std::string name = jointsCalibrations[index_calib].name;
-      std::cout << name << std::endl;
+      ROS_DEBUG_STREAM(name);
 
       std::vector<Calibration> calib = jointsCalibrations[index_calib].calibrations;
 
       std::vector<float> lookup_table((int)lookup_offset*(int)lookup_precision);
 
       if( calib.size() < 2 )
-	ROS_ERROR("Not enough points were defined to set up the calibration.");
+        ROS_ERROR("Not enough points were defined to set up the calibration.");
 
       //order the calibration vector by ascending values of raw_value
       //      ROS_ERROR("TODO: calibration vector not ordered yet");
 
-      std::cout << "lookup table : ";
+      ss << "lookup table : ";
 
       //setup the lookup table
       for( unsigned int index_lookup = 0;
-	   index_lookup < lookup_table.size() ;
-	   ++ index_lookup )
-	{
-	  float value = compute_lookup_value(index_lookup, calib);
-	  std::cout << index_lookup<<":"<<value << " ";
-	  lookup_table[index_lookup] = value;
-	}
+           index_lookup < lookup_table.size() ;
+           ++ index_lookup )
+      {
+        float value = compute_lookup_value(index_lookup, calib);
+        ss << index_lookup<<":"<<value << " ";
+        lookup_table[index_lookup] = value;
+      }
 
-      std::cout << std::endl;
+      ss << std::endl;
 
       //add the values to the map
       joints_calibrations_map[name] = lookup_table;
       //joints_calibrations_map.insert(std::pair <std::string, std::vector<float> >(name, lookup_table));
     }
-
+    ROS_DEBUG_STREAM(ss);
     return 0;
   }
 
@@ -269,7 +272,7 @@ namespace xml_calibration_parser{
       {
 	//reads from the lookup table
 	int index = return_index_from_raw_position(position);
-	std::cout << index << std::endl;
+	//std::cout << index << std::endl;
 	return iter->second[index];
       }
     else

--- a/cyberglove_trajectory/include/cyberglove_trajectory/cyberglove_trajectory_publisher.h
+++ b/cyberglove_trajectory/include/cyberglove_trajectory/cyberglove_trajectory_publisher.h
@@ -130,12 +130,12 @@ namespace cyberglove{
 
     static const std::vector<std::string> joint_name_vector_;
     static const std::vector<std::string> joint_mapping_vector_;
-    static const std::vector<std::string> glove_sensors_vector_;
 
     boost::scoped_ptr<actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> > action_client_;
     control_msgs::FollowJointTrajectoryGoal trajectory_goal_;
 
     std::string cyberglove_version_;
+    int cyberglove_joint_number_;
     std::string streaming_protocol_;
 
     ros::Duration trajectory_tx_delay_;

--- a/cyberglove_trajectory/src/cyberglove_trajectory_node.cpp
+++ b/cyberglove_trajectory/src/cyberglove_trajectory_node.cpp
@@ -48,11 +48,16 @@ using namespace cyberglove;
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "cyberglove_trajectory_node");
-
-  boost::shared_ptr<CybergloveTrajectoryPublisher> cyberglove_pub(new CybergloveTrajectoryPublisher());
-
-  ros::spin();
-
+  try
+  {
+    boost::shared_ptr<CybergloveTrajectoryPublisher> cyberglove_pub(new CybergloveTrajectoryPublisher());
+    ros::spin();
+  }
+  catch (int e)
+  {
+    ROS_FATAL("could not create trajectory publisher, leaving");
+    return -1;
+  }
   return 0;
 }
 

--- a/cyberglove_trajectory/src/cyberglove_trajectory_publisher.cpp
+++ b/cyberglove_trajectory/src/cyberglove_trajectory_publisher.cpp
@@ -87,35 +87,6 @@ const std::vector<std::string> CybergloveTrajectoryPublisher::joint_mapping_vect
                                                                                   ("LFJ5")
                                                                                   ("WRJ1")
                                                                                   ("WRJ2");
-
-
-
-
-
-//initialises joint names (the order is important)
-const std::vector<std::string> CybergloveTrajectoryPublisher::glove_sensors_vector_ = boost::assign::list_of
-                                                                                    ("G_ThumbRotate")
-                                                                                    ("G_ThumbMPJ")
-                                                                                    ("G_ThumbIJ")
-                                                                                    ("G_ThumbAb")
-                                                                                    ("G_IndexMPJ")
-                                                                                    ("G_IndexPIJ")
-                                                                                    ("G_IndexDIJ")
-                                                                                    ("G_MiddleMPJ")
-                                                                                    ("G_MiddlePIJ")
-                                                                                    ("G_MiddleDIJ")
-                                                                                    ("G_MiddleIndexAb")
-                                                                                    ("G_RingMPJ")
-                                                                                    ("G_RingPIJ")
-                                                                                    ("G_RingDIJ")
-                                                                                    ("G_RingMiddleAb")
-                                                                                    ("G_PinkieMPJ")
-                                                                                    ("G_PinkiePIJ")
-                                                                                    ("G_PinkieDIJ")
-                                                                                    ("G_PinkieRingAb")
-                                                                                    ("G_PalmArch")
-                                                                                    ("G_WristPitch")
-                                                                                    ("G_WristYaw");
   /////////////////////////////////
   //    CONSTRUCTOR/DESTRUCTOR   //
   /////////////////////////////////
@@ -147,29 +118,7 @@ const std::vector<std::string> CybergloveTrajectoryPublisher::glove_sensors_vect
 
     cyberglove_raw_pub = n_tilde.advertise<sensor_msgs::JointState>("raw/joint_states", 2);
 
-    //initialises joint names (the order is important)
-    jointstate_msg.name.push_back("G_ThumbRotate");
-    jointstate_msg.name.push_back("G_ThumbMPJ");
-    jointstate_msg.name.push_back("G_ThumbIJ");
-    jointstate_msg.name.push_back("G_ThumbAb");
-    jointstate_msg.name.push_back("G_IndexMPJ");
-    jointstate_msg.name.push_back("G_IndexPIJ");
-    jointstate_msg.name.push_back("G_IndexDIJ");
-    jointstate_msg.name.push_back("G_MiddleMPJ");
-    jointstate_msg.name.push_back("G_MiddlePIJ");
-    jointstate_msg.name.push_back("G_MiddleDIJ");
-    jointstate_msg.name.push_back("G_MiddleIndexAb");
-    jointstate_msg.name.push_back("G_RingMPJ");
-    jointstate_msg.name.push_back("G_RingPIJ");
-    jointstate_msg.name.push_back("G_RingDIJ");
-    jointstate_msg.name.push_back("G_RingMiddleAb");
-    jointstate_msg.name.push_back("G_PinkieMPJ");
-    jointstate_msg.name.push_back("G_PinkiePIJ");
-    jointstate_msg.name.push_back("G_PinkieDIJ");
-    jointstate_msg.name.push_back("G_PinkieRingAb");
-    jointstate_msg.name.push_back("G_PalmArch");
-    jointstate_msg.name.push_back("G_WristPitch");
-    jointstate_msg.name.push_back("G_WristYaw");
+   
 
 
     //set sampling frequency
@@ -188,6 +137,43 @@ const std::vector<std::string> CybergloveTrajectoryPublisher::glove_sensors_vect
     //Get the cyberglove version '2' or '3'
     n_tilde.param("cyberglove_version", cyberglove_version_, std::string("2"));
     ROS_INFO("Cyberglove version: %s", cyberglove_version_.c_str());
+    
+    //Get the cyberglove joint number '18' or '22'
+    n_tilde.param("cyberglove_joint_number", cyberglove_joint_number_, 22);
+    if (cyberglove_joint_number_ != 22 && cyberglove_joint_number_ != 18)
+    {
+      ROS_FATAL("Cybergloves with %d joints are not supported, use 18 or 22", cyberglove_joint_number_);
+      throw -1;
+    }
+    ROS_INFO("Cyberglove joint number: %d", cyberglove_joint_number_);
+
+    //initialises joint names (the order is important)      
+    jointstate_msg.name.push_back("G_ThumbRotate");
+    jointstate_msg.name.push_back("G_ThumbMPJ");
+    jointstate_msg.name.push_back("G_ThumbIJ");
+    jointstate_msg.name.push_back("G_ThumbAb");
+    jointstate_msg.name.push_back("G_IndexMPJ");
+    jointstate_msg.name.push_back("G_IndexPIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_IndexDIJ");
+    jointstate_msg.name.push_back("G_MiddleMPJ");
+    jointstate_msg.name.push_back("G_MiddlePIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_MiddleDIJ");
+    jointstate_msg.name.push_back("G_MiddleIndexAb");
+    jointstate_msg.name.push_back("G_RingMPJ");
+    jointstate_msg.name.push_back("G_RingPIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_RingDIJ");
+    jointstate_msg.name.push_back("G_RingMiddleAb");
+    jointstate_msg.name.push_back("G_PinkieMPJ");
+    jointstate_msg.name.push_back("G_PinkiePIJ");
+    if (cyberglove_joint_number_ == 22)
+      jointstate_msg.name.push_back("G_PinkieDIJ");
+    jointstate_msg.name.push_back("G_PinkieRingAb");
+    jointstate_msg.name.push_back("G_PalmArch");
+    jointstate_msg.name.push_back("G_WristPitch");
+    jointstate_msg.name.push_back("G_WristYaw");
 
     //Get the cyberglove streaming protocol '8bit' or '16bit'
     n_tilde.param("streaming_protocol", streaming_protocol_, std::string("8bit"));
@@ -302,7 +288,7 @@ const std::vector<std::string> CybergloveTrajectoryPublisher::glove_sensors_vect
       jointstate_msg.header.stamp = ros::Time::now();
 
       //fill the joint_state msg with the averaged glove data
-      for(unsigned int index_joint = 0; index_joint < CybergloveSerial::glove_size; ++index_joint)
+      for(unsigned int index_joint = 0; index_joint < cyberglove_joint_number_; ++index_joint)
       {
         //compute the average over the samples for the current joint
         float averaged_value = 0.0f;
@@ -312,7 +298,7 @@ const std::vector<std::string> CybergloveTrajectoryPublisher::glove_sensors_vect
         }
         averaged_value /= publish_counter_max;
 
-	calibration_tmp = calibration_map->find(glove_sensors_vector_[index_joint]);
+	calibration_tmp = calibration_map->find(jointstate_msg.name[index_joint]);
 	double calibration_value = calibration_tmp->compute(static_cast<double> (averaged_value));
 
 	jointstate_msg.position.push_back(averaged_value);

--- a/cyberglove_trajectory/src/cyberglove_trajectory_publisher.cpp
+++ b/cyberglove_trajectory/src/cyberglove_trajectory_publisher.cpp
@@ -197,7 +197,7 @@ const std::vector<std::string> CybergloveTrajectoryPublisher::joint_mapping_vect
     trajectory_delay_ = ros::Duration(delay);
 
     //initialize the connection with the cyberglove and binds the callback function
-    serial_glove = boost::shared_ptr<CybergloveSerial>(new CybergloveSerial(path_to_glove, cyberglove_version_, streaming_protocol_, boost::bind(&CybergloveTrajectoryPublisher::glove_callback, this, _1, _2)));
+    serial_glove = boost::shared_ptr<CybergloveSerial>(new CybergloveSerial(path_to_glove, cyberglove_version_, cyberglove_joint_number_, streaming_protocol_, boost::bind(&CybergloveTrajectoryPublisher::glove_callback, this, _1, _2)));
 
     int res = -1;
     if(cyberglove_version_ == "2")


### PR DESCRIPTION
* Main changes are to support glove size 18 or 22
* Secondary goal was to improve communication with cyberglove v1 on COM port (not USBtoSerial), which requires a little delay before flushing commands otherwise stream command S was never sent. Also fixed the end of message which does not include an extra character in the case of version 1 (according to documentation)
* Bonus changes are nicer printouts, fixed documentation, and roslint fixes (almost because unsigned short  types should maybe be kept)

Tested on v1/18 joints. I could not test it on a v2/22 joints glove. Please if you have a glove available, check it still works with it.